### PR TITLE
[FEATURE] 초기 엔티티 설정

### DIFF
--- a/src/main/java/com/linclean/LincleanApiApplication.java
+++ b/src/main/java/com/linclean/LincleanApiApplication.java
@@ -2,7 +2,9 @@ package com.linclean;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class LincleanApiApplication {
 

--- a/src/main/java/com/linclean/domain/analysis/converter/AnalysisStatusConverter.java
+++ b/src/main/java/com/linclean/domain/analysis/converter/AnalysisStatusConverter.java
@@ -1,0 +1,19 @@
+package com.linclean.domain.analysis.converter;
+
+import com.linclean.domain.analysis.entity.AnalysisStatus;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class AnalysisStatusConverter implements AttributeConverter<AnalysisStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(AnalysisStatus attribute) {
+        return attribute == null ? null : attribute.getValue();
+    }
+
+    @Override
+    public AnalysisStatus convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : AnalysisStatus.from(dbData);
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/converter/VerdictConverter.java
+++ b/src/main/java/com/linclean/domain/analysis/converter/VerdictConverter.java
@@ -1,0 +1,19 @@
+package com.linclean.domain.analysis.converter;
+
+import com.linclean.domain.analysis.entity.Verdict;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class VerdictConverter implements AttributeConverter<Verdict, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Verdict attribute) {
+        return attribute == null ? null : attribute.getValue();
+    }
+
+    @Override
+    public Verdict convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : Verdict.from(dbData);
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/entity/Analysis.java
+++ b/src/main/java/com/linclean/domain/analysis/entity/Analysis.java
@@ -1,0 +1,85 @@
+package com.linclean.domain.analysis.entity;
+
+import com.linclean.domain.analysis.converter.AnalysisStatusConverter;
+import com.linclean.domain.analysis.converter.VerdictConverter;
+import com.linclean.domain.member.entity.Member;
+import com.linclean.global.entity.BaseAuditEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "analysis")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Analysis extends BaseAuditEntity {
+
+    @Id
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    @Column(name = "analysis_id")
+    private UUID analysisId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "original_url", nullable = false, length = 2048)
+    private String originalUrl;
+
+    @Column(name = "final_url", length = 2048)
+    private String finalUrl;
+
+    @Convert(converter = AnalysisStatusConverter.class)
+    @Column(name = "status", nullable = false, length = 20)
+    @Builder.Default
+    private AnalysisStatus status = AnalysisStatus.QUEUED;
+
+    @Convert(converter = VerdictConverter.class)
+    @Column(name = "verdict", length = 20)
+    private Verdict verdict;
+
+    @Column(name = "score")
+    private Integer score;
+
+    @Column(name = "summary", columnDefinition = "TEXT")
+    private String summary;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "stages", columnDefinition = "jsonb")
+    private StagesDto stages;
+
+    @Column(name = "error_code", length = 100)
+    private String errorCode;
+
+    @Column(name = "error_stage")
+    private Integer errorStage;
+
+    @Column(name = "error_message", columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @Column(name = "engine_version", length = 50)
+    private String engineVersion;
+
+    @Column(name = "analyzed_at")
+    private Instant analyzedAt;
+
+    @Column(name = "elapsed_ms")
+    private Integer elapsedMs;
+
+    @Column(name = "request_id")
+    private UUID requestId;
+
+    @Column(name = "last_checked_at")
+    private Instant lastCheckedAt;
+}

--- a/src/main/java/com/linclean/domain/analysis/entity/AnalysisReason.java
+++ b/src/main/java/com/linclean/domain/analysis/entity/AnalysisReason.java
@@ -1,0 +1,37 @@
+package com.linclean.domain.analysis.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "analysis_reason")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class AnalysisReason {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "analysis_id", nullable = false)
+    private Analysis analysis;
+
+    @Column(name = "code", nullable = false, length = 100)
+    private String code;
+
+    @Column(name = "stage", nullable = false)
+    private int stage;
+
+    @Column(name = "weight", nullable = false)
+    private int weight;
+
+    @Column(name = "message", nullable = false, columnDefinition = "TEXT")
+    private String message;
+}

--- a/src/main/java/com/linclean/domain/analysis/entity/AnalysisStatus.java
+++ b/src/main/java/com/linclean/domain/analysis/entity/AnalysisStatus.java
@@ -1,0 +1,29 @@
+package com.linclean.domain.analysis.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum AnalysisStatus {
+    QUEUED("queued"),
+    SUCCEEDED("succeeded"),
+    FAILED("failed");
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static AnalysisStatus from(String value) {
+        for (AnalysisStatus status : values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown AnalysisStatus: " + value);
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/entity/StagesDto.java
+++ b/src/main/java/com/linclean/domain/analysis/entity/StagesDto.java
@@ -1,0 +1,70 @@
+package com.linclean.domain.analysis.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class StagesDto {
+
+    private ExternalDbStage externalDb;
+    private UnchainStage unchain;
+    private DomainHeuristicStage domainHeuristic;
+    private ContentAnalysisStage contentAnalysis;
+
+    @Getter
+    @NoArgsConstructor
+    public static class ExternalDbStage {
+        private GsbResult gsb;
+        private UrlHausResult urlhaus;
+
+        @Getter
+        @NoArgsConstructor
+        public static class GsbResult {
+            private boolean isThreat;
+            private List<String> matchedTypes;
+        }
+
+        @Getter
+        @NoArgsConstructor
+        public static class UrlHausResult {
+            private boolean isThreat;
+            private String host;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class UnchainStage {
+        private int hops;
+        private List<String> chain;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class DomainHeuristicStage {
+        private RdapInfo rdap;
+        private List<String> signals;
+
+        @Getter
+        @NoArgsConstructor
+        public static class RdapInfo {
+            private String domain;
+            private String registrar;
+            private String createdDate;
+            private int domainAgeDays;
+            private boolean isNewDomain;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ContentAnalysisStage {
+        private boolean fetched;
+        private boolean hasPasswordField;
+        private String aiVerdict;
+        private String aiReason;
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/entity/Verdict.java
+++ b/src/main/java/com/linclean/domain/analysis/entity/Verdict.java
@@ -1,0 +1,29 @@
+package com.linclean.domain.analysis.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Verdict {
+    SAFE("safe"),
+    CAUTION("caution"),
+    DANGER("danger");
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static Verdict from(String value) {
+        for (Verdict verdict : values()) {
+            if (verdict.value.equals(value)) {
+                return verdict;
+            }
+        }
+        throw new IllegalArgumentException("Unknown Verdict: " + value);
+    }
+}

--- a/src/main/java/com/linclean/domain/device/converter/DeviceTypeConverter.java
+++ b/src/main/java/com/linclean/domain/device/converter/DeviceTypeConverter.java
@@ -1,0 +1,19 @@
+package com.linclean.domain.device.converter;
+
+import com.linclean.domain.device.entity.DeviceType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class DeviceTypeConverter implements AttributeConverter<DeviceType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(DeviceType attribute) {
+        return attribute == null ? null : attribute.getValue();
+    }
+
+    @Override
+    public DeviceType convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : DeviceType.from(dbData);
+    }
+}

--- a/src/main/java/com/linclean/domain/device/entity/DeviceToken.java
+++ b/src/main/java/com/linclean/domain/device/entity/DeviceToken.java
@@ -1,0 +1,31 @@
+package com.linclean.domain.device.entity;
+
+import com.linclean.domain.device.converter.DeviceTypeConverter;
+import com.linclean.global.entity.BaseEntity;
+import com.linclean.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "device_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class DeviceToken extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "fcm_token", nullable = false, unique = true, length = 512)
+    private String fcmToken;
+
+    @Convert(converter = DeviceTypeConverter.class)
+    @Column(name = "device_type", nullable = false, length = 20)
+    private DeviceType deviceType;
+}

--- a/src/main/java/com/linclean/domain/device/entity/DeviceType.java
+++ b/src/main/java/com/linclean/domain/device/entity/DeviceType.java
@@ -1,0 +1,28 @@
+package com.linclean.domain.device.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum DeviceType {
+    IOS("ios"),
+    ANDROID("android");
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static DeviceType from(String value) {
+        for (DeviceType type : values()) {
+            if (type.value.equals(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown DeviceType: " + value);
+    }
+}

--- a/src/main/java/com/linclean/domain/link/entity/Category.java
+++ b/src/main/java/com/linclean/domain/link/entity/Category.java
@@ -1,0 +1,30 @@
+package com.linclean.domain.link.entity;
+
+import com.linclean.global.entity.BaseCreatedEntity;
+import com.linclean.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Category extends BaseCreatedEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "display_order", nullable = false)
+    @Builder.Default
+    private int displayOrder = 0;
+}

--- a/src/main/java/com/linclean/domain/link/entity/SavedLink.java
+++ b/src/main/java/com/linclean/domain/link/entity/SavedLink.java
@@ -1,0 +1,51 @@
+package com.linclean.domain.link.entity;
+
+import com.linclean.domain.analysis.entity.Analysis;
+import com.linclean.global.entity.BaseEntity;
+import com.linclean.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "saved_link")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class SavedLink extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "analysis_id", nullable = false)
+    private Analysis analysis;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Column(name = "original_url", nullable = false, length = 2048)
+    private String originalUrl;
+
+    @Column(name = "final_url", length = 2048)
+    private String finalUrl;
+
+    @Column(name = "title", length = 500)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "site_name", length = 255)
+    private String siteName;
+
+    @Column(name = "is_bookmarked", nullable = false)
+    @Builder.Default
+    private boolean isBookmarked = false;
+}

--- a/src/main/java/com/linclean/domain/member/entity/Member.java
+++ b/src/main/java/com/linclean/domain/member/entity/Member.java
@@ -1,0 +1,41 @@
+package com.linclean.domain.member.entity;
+
+import com.linclean.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@SQLDelete(sql = "UPDATE member SET deleted_at = now(), updated_at = now() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class Member extends BaseEntity {
+
+    @Column(name = "public_id", nullable = false, unique = true, updatable = false)
+    private UUID publicId;
+
+    @Column(name = "kakao_id", nullable = false, unique = true)
+    private String kakaoId;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    @PrePersist
+    private void assignPublicId() {
+        if (this.publicId == null) {
+            this.publicId = UUID.randomUUID();
+        }
+    }
+}

--- a/src/main/java/com/linclean/domain/notice/entity/Notice.java
+++ b/src/main/java/com/linclean/domain/notice/entity/Notice.java
@@ -1,0 +1,28 @@
+package com.linclean.domain.notice.entity;
+
+import com.linclean.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "notice")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Notice extends BaseEntity {
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "is_pinned", nullable = false)
+    @Builder.Default
+    private boolean isPinned = false;
+}

--- a/src/main/java/com/linclean/domain/notification/converter/NotificationTypeConverter.java
+++ b/src/main/java/com/linclean/domain/notification/converter/NotificationTypeConverter.java
@@ -1,0 +1,19 @@
+package com.linclean.domain.notification.converter;
+
+import com.linclean.domain.notification.entity.NotificationType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class NotificationTypeConverter implements AttributeConverter<NotificationType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(NotificationType attribute) {
+        return attribute == null ? null : attribute.getValue();
+    }
+
+    @Override
+    public NotificationType convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : NotificationType.from(dbData);
+    }
+}

--- a/src/main/java/com/linclean/domain/notification/entity/Notification.java
+++ b/src/main/java/com/linclean/domain/notification/entity/Notification.java
@@ -1,0 +1,41 @@
+package com.linclean.domain.notification.entity;
+
+import com.linclean.domain.notification.converter.NotificationTypeConverter;
+import com.linclean.global.entity.BaseCreatedEntity;
+import com.linclean.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "notification")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Notification extends BaseCreatedEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Convert(converter = NotificationTypeConverter.class)
+    @Column(name = "type", nullable = false, length = 50)
+    private NotificationType type;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "body", columnDefinition = "TEXT")
+    private String body;
+
+    @Column(name = "target_url", length = 2048)
+    private String targetUrl;
+
+    @Column(name = "is_read", nullable = false)
+    @Builder.Default
+    private boolean isRead = false;
+}

--- a/src/main/java/com/linclean/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/linclean/domain/notification/entity/NotificationType.java
@@ -1,0 +1,27 @@
+package com.linclean.domain.notification.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum NotificationType {
+    ANALYSIS_COMPLETE("analysis_complete");
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static NotificationType from(String value) {
+        for (NotificationType type : values()) {
+            if (type.value.equals(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown NotificationType: " + value);
+    }
+}

--- a/src/main/java/com/linclean/global/entity/BaseAuditEntity.java
+++ b/src/main/java/com/linclean/global/entity/BaseAuditEntity.java
@@ -1,0 +1,25 @@
+package com.linclean.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseAuditEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/src/main/java/com/linclean/global/entity/BaseCreatedEntity.java
+++ b/src/main/java/com/linclean/global/entity/BaseCreatedEntity.java
@@ -1,0 +1,22 @@
+package com.linclean.global.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/src/main/java/com/linclean/global/entity/BaseEntity.java
+++ b/src/main/java/com/linclean/global/entity/BaseEntity.java
@@ -1,0 +1,16 @@
+package com.linclean.global.entity;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity extends BaseAuditEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none # 엔티티 생성 이후 update로 변경
+      ddl-auto: none # 엔티티 변경 후 검증 시에만 잠시 validate 변경
     open-in-view: false
     properties:
       hibernate:

--- a/src/main/resources/db/init.sql
+++ b/src/main/resources/db/init.sql
@@ -14,7 +14,7 @@ CREATE TABLE member (
                         kakao_id        VARCHAR(255)    NOT NULL,
                         created_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
                         updated_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
-                        is_deleted      BOOLEAN         NOT NULL DEFAULT FALSE,
+                        deleted_at      TIMESTAMPTZ,
 
                         CONSTRAINT uq_member_public_id  UNIQUE (public_id),
                         CONSTRAINT uq_member_kakao_id   UNIQUE (kakao_id)

--- a/src/main/resources/db/init.sql
+++ b/src/main/resources/db/init.sql
@@ -1,0 +1,188 @@
+-- ============================================================
+-- LinClean ERD - PostgreSQL 17 DDL
+-- ============================================================
+
+-- UUID 생성용 확장 모듈
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ============================================================
+-- 1. MEMBER
+-- ============================================================
+CREATE TABLE member (
+                        id              BIGINT          GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                        public_id       UUID            NOT NULL DEFAULT gen_random_uuid(),
+                        kakao_id        VARCHAR(255)    NOT NULL,
+                        created_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+                        updated_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+                        is_deleted      BOOLEAN         NOT NULL DEFAULT FALSE,
+
+                        CONSTRAINT uq_member_public_id  UNIQUE (public_id),
+                        CONSTRAINT uq_member_kakao_id   UNIQUE (kakao_id)
+);
+
+-- ============================================================
+-- 2. DEVICE_TOKEN
+-- ============================================================
+CREATE TABLE device_token (
+                              id              BIGINT          GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                              member_id       BIGINT          NOT NULL,
+                              fcm_token       VARCHAR(512)    NOT NULL,
+                              device_type     VARCHAR(20)     NOT NULL,
+                              created_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+                              updated_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+
+                              CONSTRAINT uq_device_token_fcm  UNIQUE (fcm_token),
+                              CONSTRAINT fk_device_token_member
+                                  FOREIGN KEY (member_id) REFERENCES member (id)
+                                      ON DELETE CASCADE
+);
+
+CREATE INDEX idx_device_token_member_id ON device_token (member_id);
+
+-- ============================================================
+-- 3. NOTIFICATION
+-- ============================================================
+CREATE TABLE notification (
+                              id              BIGINT          GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                              member_id       BIGINT          NOT NULL,
+                              type            VARCHAR(50)     NOT NULL,
+                              title           VARCHAR(255)    NOT NULL,
+                              body            TEXT,
+                              target_url      VARCHAR(2048),
+                              is_read         BOOLEAN         NOT NULL DEFAULT FALSE,
+                              created_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+
+                              CONSTRAINT fk_notification_member
+                                  FOREIGN KEY (member_id) REFERENCES member (id)
+                                      ON DELETE CASCADE
+);
+
+CREATE INDEX idx_notification_member_id ON notification (member_id);
+CREATE INDEX idx_notification_member_read ON notification (member_id, is_read);
+
+-- ============================================================
+-- 4. ANALYSIS
+-- ============================================================
+CREATE TABLE analysis (
+                          analysis_id     UUID            PRIMARY KEY,
+                          member_id       BIGINT          NOT NULL,
+                          original_url    VARCHAR(2048)   NOT NULL,
+                          final_url       VARCHAR(2048),
+                          status          VARCHAR(20)     NOT NULL DEFAULT 'queued',
+                          verdict         VARCHAR(20),
+                          score           INTEGER,
+                          summary         TEXT,
+                          stages          JSONB,
+                          error_code      VARCHAR(100),
+                          error_stage     INTEGER,
+                          error_message   TEXT,
+                          engine_version  VARCHAR(50),
+                          analyzed_at     TIMESTAMPTZ,
+                          elapsed_ms      INTEGER,
+                          request_id      UUID,
+                          last_checked_at TIMESTAMPTZ,
+                          created_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+                          updated_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+
+                          CONSTRAINT fk_analysis_member
+                              FOREIGN KEY (member_id) REFERENCES member (id)
+                                  ON DELETE CASCADE,
+
+                          CONSTRAINT chk_analysis_status
+                              CHECK (status IN ('queued', 'succeeded', 'failed')),
+                          CONSTRAINT chk_analysis_verdict
+                              CHECK (verdict IS NULL OR verdict IN ('safe', 'caution', 'danger')),
+                          CONSTRAINT chk_analysis_score
+                              CHECK (score IS NULL OR score BETWEEN 0 AND 100)
+);
+
+CREATE INDEX idx_analysis_member_id ON analysis (member_id);
+CREATE INDEX idx_analysis_status ON analysis (status);
+CREATE INDEX idx_analysis_member_status ON analysis (member_id, status);
+CREATE INDEX idx_analysis_last_checked ON analysis (last_checked_at);
+
+-- ============================================================
+-- 5. ANALYSIS_REASON
+-- ============================================================
+CREATE TABLE analysis_reason (
+                                 id              BIGINT          GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                                 analysis_id     UUID            NOT NULL,
+                                 code            VARCHAR(100)    NOT NULL,
+                                 stage           INTEGER         NOT NULL,
+                                 weight          INTEGER         NOT NULL,
+                                 message         TEXT            NOT NULL,
+
+                                 CONSTRAINT fk_reason_analysis
+                                     FOREIGN KEY (analysis_id) REFERENCES analysis (analysis_id)
+                                         ON DELETE CASCADE,
+
+                                 CONSTRAINT chk_reason_stage
+                                     CHECK (stage BETWEEN 1 AND 4)
+);
+
+CREATE INDEX idx_analysis_reason_analysis_id ON analysis_reason (analysis_id);
+
+-- ============================================================
+-- 6. CATEGORY
+-- ============================================================
+CREATE TABLE category (
+                          id              BIGINT          GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                          member_id       BIGINT          NOT NULL,
+                          name            VARCHAR(50)     NOT NULL,
+                          display_order   INTEGER         NOT NULL DEFAULT 0,
+                          created_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+
+                          CONSTRAINT fk_category_member
+                              FOREIGN KEY (member_id) REFERENCES member (id)
+                                  ON DELETE CASCADE,
+
+                          CONSTRAINT uq_category_member_name
+                              UNIQUE (member_id, name)
+);
+
+CREATE INDEX idx_category_member_id ON category (member_id);
+
+-- ============================================================
+-- 7. SAVED_LINK
+-- ============================================================
+CREATE TABLE saved_link (
+                            id              BIGINT          GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                            member_id       BIGINT          NOT NULL,
+                            analysis_id     UUID            NOT NULL,
+                            category_id     BIGINT,
+                            original_url    VARCHAR(2048)   NOT NULL,
+                            final_url       VARCHAR(2048),
+                            title           VARCHAR(500),
+                            description     TEXT,
+                            site_name       VARCHAR(255),
+                            is_bookmarked   BOOLEAN         NOT NULL DEFAULT FALSE,
+                            created_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+                            updated_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+
+                            CONSTRAINT fk_saved_link_member
+                                FOREIGN KEY (member_id) REFERENCES member (id)
+                                    ON DELETE CASCADE,
+                            CONSTRAINT fk_saved_link_analysis
+                                FOREIGN KEY (analysis_id) REFERENCES analysis (analysis_id)
+                                    ON DELETE CASCADE,
+                            CONSTRAINT fk_saved_link_category
+                                FOREIGN KEY (category_id) REFERENCES category (id)
+                                    ON DELETE SET NULL
+);
+
+CREATE INDEX idx_saved_link_member_id ON saved_link (member_id);
+CREATE INDEX idx_saved_link_analysis_id ON saved_link (analysis_id);
+CREATE INDEX idx_saved_link_category_id ON saved_link (category_id);
+CREATE INDEX idx_saved_link_member_bookmark ON saved_link (member_id, is_bookmarked);
+
+-- ============================================================
+-- 8. NOTICE
+-- ============================================================
+CREATE TABLE notice (
+                        id              BIGINT          GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                        title           VARCHAR(255)    NOT NULL,
+                        content         TEXT            NOT NULL,
+                        is_pinned       BOOLEAN         NOT NULL DEFAULT FALSE,
+                        created_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+                        updated_at      TIMESTAMPTZ     NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
<img width="3014" height="1884" alt="image" src="https://github.com/user-attachments/assets/f29f53b3-fcdb-4eb1-8e7c-38b7809de765" />

## 1. DB 스키마 (DDL) — src/main/resources/db/init.sql
86a4808 초기 DDL 추가 

- BIGSERIAL 대신 GENERATED ALWAYS AS IDENTITY → 외부에서 ID 임의 삽입 방지

- TIMESTAMP 대신 TIMESTAMPTZ → 서버 로케일과 무관한 정확한 시각 보장

- FK에 ON DELETE CASCADE / ON DELETE SET NULL 명시 → 회원 탈퇴 시 연관 데이터 정리 정책을 DB 레벨에서 보장

- category_id는 SET NULL → 카테고리 삭제 시 링크는 "미분류" 상태로 유지

- last_checked_at 인덱스 → 재검사 스케줄러 조회 최적화

b20e1a4 is_deleted 컬럼 수정

- BOOLEAN → TIMESTAMPTZ로 변경 (soft delete 시각 저장)

- NOT NULL 제약 제거

### 2. 공통 Base 엔티티 — global/entity/
67f6051 baseentity 추가

- BaseCreatedEntity: createdAt만 가지는 최소 엔티티

- BaseAuditEntity: createdAt + updatedAt 포함

- BaseEntity: 위 두 개의 공통 부모 (@MappedSuperclass)

f9f76db @EnableJpaAuditing 추가

- LincleanApiApplication에 애노테이션 추가 → JPA Auditing 기능 활성화

enum 필드가 있는 도메인(analysis, device, notification)은 모두 AttributeConverter 구현체를 함께 두고 있습니다. 
이를 통해 DB에는 코드값으로 저장하되, Java 애플리케이션 내에서는 enum 객체로 다루는 구조를 일관되게 구성했습니다.

# 연관 이슈 및 Close 할 이슈 작성
(fix #일이삼)
<!--이슈 번호를 적어주세요(예시: fix #123). -->

-- PR 시 다음과 같이 작성
#8 

close #8 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
   