### PR TITLE
[FEATURE] 카카오 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -40,8 +43,17 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // JWT (JJWT 0.12.6)
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly    'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly    'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/linclean/auth/client/KakaoApiClient.java
+++ b/src/main/java/com/linclean/auth/client/KakaoApiClient.java
@@ -25,15 +25,18 @@ public class KakaoApiClient {
                 .uri(USER_ME_PATH)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + kakaoAccessToken)
                 .retrieve()
+                // 401: 클라이언트가 보낸 카카오 토큰이 유효하지 않음
                 .onStatus(
                         status -> status == HttpStatus.UNAUTHORIZED,
                         response -> Mono.error(new KakaoAuthException(ErrorCode.INVALID_KAKAO_TOKEN))
                 )
+                // 5xx: 카카오 서버 자체 문제
                 .onStatus(
                         status -> status.is5xxServerError(),
                         response -> Mono.error(new KakaoAuthException(ErrorCode.KAKAO_SERVER_ERROR))
                 )
                 .bodyToMono(KakaoUserResponse.class)
+                // 타임아웃, 역직렬화 실패 등 나머지 예외는 모두 서버 오류로 통일
                 .onErrorMap(
                         e -> !(e instanceof KakaoAuthException),
                         e -> {

--- a/src/main/java/com/linclean/auth/client/KakaoApiClient.java
+++ b/src/main/java/com/linclean/auth/client/KakaoApiClient.java
@@ -1,0 +1,46 @@
+package com.linclean.auth.client;
+
+import com.linclean.auth.dto.response.KakaoUserResponse;
+import com.linclean.auth.exception.KakaoAuthException;
+import com.linclean.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoApiClient {
+
+    private static final String USER_ME_PATH = "/v2/user/me";
+
+    private final WebClient kakaoWebClient;
+
+    public KakaoUserResponse getUserInfo(String kakaoAccessToken) {
+        return kakaoWebClient.get()
+                .uri(USER_ME_PATH)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + kakaoAccessToken)
+                .retrieve()
+                .onStatus(
+                        status -> status == HttpStatus.UNAUTHORIZED,
+                        response -> Mono.error(new KakaoAuthException(ErrorCode.INVALID_KAKAO_TOKEN))
+                )
+                .onStatus(
+                        status -> status.is5xxServerError(),
+                        response -> Mono.error(new KakaoAuthException(ErrorCode.KAKAO_SERVER_ERROR))
+                )
+                .bodyToMono(KakaoUserResponse.class)
+                .onErrorMap(
+                        e -> !(e instanceof KakaoAuthException),
+                        e -> {
+                            log.error("카카오 API 호출 실패: {}", e.getMessage(), e);
+                            return new KakaoAuthException(ErrorCode.KAKAO_SERVER_ERROR);
+                        }
+                )
+                .block();
+    }
+}

--- a/src/main/java/com/linclean/auth/controller/AuthController.java
+++ b/src/main/java/com/linclean/auth/controller/AuthController.java
@@ -1,0 +1,39 @@
+package com.linclean.auth.controller;
+
+import com.linclean.auth.dto.request.KakaoLoginRequest;
+import com.linclean.auth.dto.request.RefreshRequest;
+import com.linclean.auth.dto.response.TokenResponse;
+import com.linclean.auth.jwt.MemberPrincipal;
+import com.linclean.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/kakao/login")
+    public ResponseEntity<TokenResponse> kakaoLogin(
+            @Valid @RequestBody KakaoLoginRequest request) {
+        return ResponseEntity.ok(authService.loginWithKakao(request));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(
+            @Valid @RequestBody RefreshRequest request) {
+        return ResponseEntity.ok(authService.refresh(request));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @AuthenticationPrincipal MemberPrincipal principal) {
+        authService.logout(principal.memberId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/linclean/auth/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/linclean/auth/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,8 @@
+package com.linclean.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoLoginRequest(
+        @NotBlank(message = "카카오 액세스 토큰은 필수입니다.")
+        String kakaoAccessToken
+) {}

--- a/src/main/java/com/linclean/auth/dto/request/RefreshRequest.java
+++ b/src/main/java/com/linclean/auth/dto/request/RefreshRequest.java
@@ -1,0 +1,8 @@
+package com.linclean.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+        @NotBlank(message = "Refresh Token은 필수입니다.")
+        String refreshToken
+) {}

--- a/src/main/java/com/linclean/auth/dto/response/KakaoUserResponse.java
+++ b/src/main/java/com/linclean/auth/dto/response/KakaoUserResponse.java
@@ -1,0 +1,12 @@
+package com.linclean.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserResponse(
+        Long id,
+        @JsonProperty("connected_at") String connectedAt
+) {
+    public String kakaoId() {
+        return String.valueOf(id);
+    }
+}

--- a/src/main/java/com/linclean/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/linclean/auth/dto/response/TokenResponse.java
@@ -1,0 +1,19 @@
+package com.linclean.auth.dto.response;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken,
+        String tokenType,
+        long expiresIn,
+        Boolean isNewMember
+) {
+    public static TokenResponse ofLogin(
+            String accessToken, String refreshToken, long expiresIn, boolean isNewMember) {
+        return new TokenResponse(accessToken, refreshToken, "Bearer", expiresIn, isNewMember);
+    }
+
+    public static TokenResponse ofRefresh(
+            String accessToken, String refreshToken, long expiresIn) {
+        return new TokenResponse(accessToken, refreshToken, "Bearer", expiresIn, null);
+    }
+}

--- a/src/main/java/com/linclean/auth/exception/InvalidTokenException.java
+++ b/src/main/java/com/linclean/auth/exception/InvalidTokenException.java
@@ -1,0 +1,14 @@
+package com.linclean.auth.exception;
+
+import com.linclean.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class InvalidTokenException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public InvalidTokenException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/linclean/auth/exception/KakaoAuthException.java
+++ b/src/main/java/com/linclean/auth/exception/KakaoAuthException.java
@@ -1,0 +1,14 @@
+package com.linclean.auth.exception;
+
+import com.linclean.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class KakaoAuthException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public KakaoAuthException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/linclean/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/linclean/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.linclean.auth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linclean.global.exception.ErrorCode;
+import com.linclean.global.exception.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(ErrorCode.INVALID_TOKEN));
+    }
+}

--- a/src/main/java/com/linclean/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/linclean/auth/jwt/JwtAuthenticationFilter.java
@@ -45,7 +45,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         try {
             Claims claims = jwtProvider.parseAccessToken(token);
-            Long memberId = ((Number) claims.get("mid")).longValue();
+            Long memberId = jwtProvider.extractMemberId(claims);
             UUID publicId = UUID.fromString(claims.getSubject());
 
             MemberPrincipal principal = new MemberPrincipal(memberId, publicId);

--- a/src/main/java/com/linclean/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/linclean/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,78 @@
+package com.linclean.auth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linclean.auth.exception.InvalidTokenException;
+import com.linclean.global.exception.ErrorResponse;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String token = extractToken(request);
+        if (token == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            Claims claims = jwtProvider.parseAccessToken(token);
+            Long memberId = ((Number) claims.get("mid")).longValue();
+            UUID publicId = UUID.fromString(claims.getSubject());
+
+            MemberPrincipal principal = new MemberPrincipal(memberId, publicId);
+            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                    principal, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER")));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+
+        } catch (InvalidTokenException e) {
+            sendErrorResponse(response, e);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, InvalidTokenException e)
+            throws IOException {
+        response.setStatus(e.getErrorCode().getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(e.getErrorCode()));
+    }
+}

--- a/src/main/java/com/linclean/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/linclean/auth/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.linclean.auth.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linclean.auth.exception.InvalidTokenException;
+import com.linclean.global.exception.ErrorCode;
 import com.linclean.global.exception.ErrorResponse;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -54,6 +55,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         } catch (InvalidTokenException e) {
             sendErrorResponse(response, e);
+            return;
+        } catch (ClassCastException | IllegalArgumentException e) {
+            sendErrorResponse(response, new InvalidTokenException(ErrorCode.INVALID_TOKEN));
             return;
         }
 

--- a/src/main/java/com/linclean/auth/jwt/JwtProperties.java
+++ b/src/main/java/com/linclean/auth/jwt/JwtProperties.java
@@ -1,0 +1,10 @@
+package com.linclean.auth.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        long accessTokenExpiry,
+        long refreshTokenExpiry
+) {}

--- a/src/main/java/com/linclean/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/linclean/auth/jwt/JwtProvider.java
@@ -1,0 +1,97 @@
+package com.linclean.auth.jwt;
+
+import com.linclean.auth.exception.InvalidTokenException;
+import com.linclean.domain.member.entity.Member;
+import com.linclean.global.exception.ErrorCode;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private static final String CLAIM_MEMBER_ID = "mid";
+    private static final String CLAIM_TYPE = "type";
+    private static final String TYPE_ACCESS = "access";
+    private static final String TYPE_REFRESH = "refresh";
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpirySeconds;
+    private final long refreshTokenExpirySeconds;
+
+    public JwtProvider(JwtProperties properties) {
+        this.secretKey = Keys.hmacShaKeyFor(
+                properties.secret().getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpirySeconds = properties.accessTokenExpiry();
+        this.refreshTokenExpirySeconds = properties.refreshTokenExpiry();
+    }
+
+    public String createAccessToken(Member member) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(member.getPublicId().toString())
+                .claim(CLAIM_MEMBER_ID, member.getId())
+                .claim(CLAIM_TYPE, TYPE_ACCESS)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusSeconds(accessTokenExpirySeconds)))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken(Member member) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(member.getPublicId().toString())
+                .claim(CLAIM_MEMBER_ID, member.getId())
+                .claim(CLAIM_TYPE, TYPE_REFRESH)
+                .id(UUID.randomUUID().toString())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusSeconds(refreshTokenExpirySeconds)))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Claims parseAccessToken(String token) {
+        Claims claims = parseClaims(token);
+        if (!TYPE_ACCESS.equals(claims.get(CLAIM_TYPE, String.class))) {
+            throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
+        }
+        return claims;
+    }
+
+    public Claims parseRefreshToken(String token) {
+        Claims claims = parseClaims(token);
+        if (!TYPE_REFRESH.equals(claims.get(CLAIM_TYPE, String.class))) {
+            throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
+        }
+        return claims;
+    }
+
+    public String extractJti(Claims claims) {
+        return claims.getId();
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new InvalidTokenException(ErrorCode.TOKEN_EXPIRED);
+        } catch (SignatureException | MalformedJwtException | UnsupportedJwtException |
+                 IllegalArgumentException e) {
+            throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/linclean/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/linclean/auth/jwt/JwtProvider.java
@@ -76,6 +76,10 @@ public class JwtProvider {
         return claims;
     }
 
+    public Long extractMemberId(Claims claims) {
+        return ((Number) claims.get(CLAIM_MEMBER_ID)).longValue();
+    }
+
     public String extractJti(Claims claims) {
         return claims.getId();
     }

--- a/src/main/java/com/linclean/auth/jwt/MemberPrincipal.java
+++ b/src/main/java/com/linclean/auth/jwt/MemberPrincipal.java
@@ -1,0 +1,5 @@
+package com.linclean.auth.jwt;
+
+import java.util.UUID;
+
+public record MemberPrincipal(Long memberId, UUID publicId) {}

--- a/src/main/java/com/linclean/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/linclean/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,59 @@
+package com.linclean.auth.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+    private static final String KEY_PREFIX = "refresh:";
+    private static final String KEY_FORMAT = "refresh:%d:%s"; // refresh:{memberId}:{jti}
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void save(Long memberId, String jti, UUID publicId, Duration ttl) {
+        String key = buildKey(memberId, jti);
+        redisTemplate.opsForValue().set(key, publicId.toString(), ttl);
+    }
+
+    public Optional<String> findPublicIdByMemberIdAndJti(Long memberId, String jti) {
+        String key = buildKey(memberId, jti);
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key));
+    }
+
+    public void deleteByMemberIdAndJti(Long memberId, String jti) {
+        redisTemplate.delete(buildKey(memberId, jti));
+    }
+
+    /** 멤버의 모든 RT 삭제 (로그아웃, 재사용 공격 감지). SCAN 사용. */
+    public void deleteAllByMemberId(Long memberId) {
+        String pattern = KEY_PREFIX + memberId + ":*";
+        ScanOptions options = ScanOptions.scanOptions().match(pattern).count(100).build();
+
+        List<String> keysToDelete = new ArrayList<>();
+        try (Cursor<String> cursor = redisTemplate.scan(options)) {
+            cursor.forEachRemaining(keysToDelete::add);
+        }
+
+        if (!keysToDelete.isEmpty()) {
+            redisTemplate.delete(keysToDelete);
+            log.info("멤버 {}의 Refresh Token {} 개 삭제", memberId, keysToDelete.size());
+        }
+    }
+
+    private String buildKey(Long memberId, String jti) {
+        return String.format(KEY_FORMAT, memberId, jti);
+    }
+}

--- a/src/main/java/com/linclean/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/linclean/auth/repository/RefreshTokenRepository.java
@@ -33,6 +33,12 @@ public class RefreshTokenRepository {
         return Optional.ofNullable(redisTemplate.opsForValue().get(key));
     }
 
+    /** jti 확인과 동시에 삭제 (원자적 GETDEL). RTR의 1회성 보장. */
+    public Optional<String> findAndDeleteByMemberIdAndJti(Long memberId, String jti) {
+        String key = buildKey(memberId, jti);
+        return Optional.ofNullable(redisTemplate.opsForValue().getAndDelete(key));
+    }
+
     public void deleteByMemberIdAndJti(Long memberId, String jti) {
         redisTemplate.delete(buildKey(memberId, jti));
     }

--- a/src/main/java/com/linclean/auth/service/AuthService.java
+++ b/src/main/java/com/linclean/auth/service/AuthService.java
@@ -31,8 +31,10 @@ public class AuthService {
 
     @Transactional
     public TokenResponse loginWithKakao(KakaoLoginRequest request) {
+        // 카카오 토큰으로 kakaoId 조회 (토큰 위변조 검증 포함)
         String kakaoId = kakaoOAuthService.getKakaoId(request.kakaoAccessToken());
 
+        // 기존 회원이면 재사용, 없으면 신규 가입 처리
         var existing = memberRepository.findByKakaoId(kakaoId);
         Member member = existing.orElseGet(() ->
                 memberRepository.save(Member.builder().kakaoId(kakaoId).build()));
@@ -46,10 +48,13 @@ public class AuthService {
         Long memberId = jwtProvider.extractMemberId(claims);
         String jti = jwtProvider.extractJti(claims);
 
+        // GETDEL로 원자적 조회+삭제 — 동시 요청이 와도 한 쪽만 성공
         boolean deleted = refreshTokenRepository
                 .findAndDeleteByMemberIdAndJti(memberId, jti).isPresent();
 
         if (!deleted) {
+            // Redis에 없는 jti → 이미 사용된 RT 재사용 시도
+            // 토큰 탈취 가능성이 있으므로 해당 멤버의 모든 RT를 무효화
             log.warn("Refresh Token 재사용 공격 감지! memberId={}, jti={}", memberId, jti);
             refreshTokenRepository.deleteAllByMemberId(memberId);
             throw new InvalidTokenException(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
@@ -58,6 +63,7 @@ public class AuthService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_TOKEN));
 
+        // 검증 통과 → 새 AT/RT 발급 (RTR: 기존 RT는 위에서 이미 삭제됨)
         return rotateTokens(member);
     }
 
@@ -80,6 +86,7 @@ public class AuthService {
         String accessToken = jwtProvider.createAccessToken(member);
         String refreshToken = jwtProvider.createRefreshToken(member);
 
+        // RT의 jti를 Redis key로 사용해 개별 토큰 단위 무효화 지원
         Claims refreshClaims = jwtProvider.parseRefreshToken(refreshToken);
         String jti = jwtProvider.extractJti(refreshClaims);
 

--- a/src/main/java/com/linclean/auth/service/AuthService.java
+++ b/src/main/java/com/linclean/auth/service/AuthService.java
@@ -33,14 +33,12 @@ public class AuthService {
     public TokenResponse loginWithKakao(KakaoLoginRequest request) {
         String kakaoId = kakaoOAuthService.getKakaoId(request.kakaoAccessToken());
 
-        boolean[] isNew = {false};
-        Member member = memberRepository.findByKakaoId(kakaoId)
-                .orElseGet(() -> {
-                    isNew[0] = true;
-                    return memberRepository.save(Member.builder().kakaoId(kakaoId).build());
-                });
+        var existing = memberRepository.findByKakaoId(kakaoId);
+        Member member = existing.orElseGet(() ->
+                memberRepository.save(Member.builder().kakaoId(kakaoId).build()));
+        boolean isNewMember = existing.isEmpty();
 
-        return issueTokens(member, isNew[0]);
+        return issueTokens(member, isNewMember);
     }
 
     @Transactional(readOnly = true)
@@ -49,16 +47,14 @@ public class AuthService {
         Long memberId = ((Number) claims.get("mid")).longValue();
         String jti = jwtProvider.extractJti(claims);
 
-        boolean exists = refreshTokenRepository
-                .findPublicIdByMemberIdAndJti(memberId, jti).isPresent();
+        boolean deleted = refreshTokenRepository
+                .findAndDeleteByMemberIdAndJti(memberId, jti).isPresent();
 
-        if (!exists) {
+        if (!deleted) {
             log.warn("Refresh Token 재사용 공격 감지! memberId={}, jti={}", memberId, jti);
             refreshTokenRepository.deleteAllByMemberId(memberId);
             throw new InvalidTokenException(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
         }
-
-        refreshTokenRepository.deleteByMemberIdAndJti(memberId, jti);
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_TOKEN));

--- a/src/main/java/com/linclean/auth/service/AuthService.java
+++ b/src/main/java/com/linclean/auth/service/AuthService.java
@@ -1,0 +1,89 @@
+package com.linclean.auth.service;
+
+import com.linclean.auth.dto.request.KakaoLoginRequest;
+import com.linclean.auth.dto.request.RefreshRequest;
+import com.linclean.auth.dto.response.TokenResponse;
+import com.linclean.auth.exception.InvalidTokenException;
+import com.linclean.auth.jwt.JwtProperties;
+import com.linclean.auth.jwt.JwtProvider;
+import com.linclean.auth.repository.RefreshTokenRepository;
+import com.linclean.domain.member.entity.Member;
+import com.linclean.domain.member.repository.MemberRepository;
+import com.linclean.global.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoOAuthService kakaoOAuthService;
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProperties jwtProperties;
+
+    @Transactional
+    public TokenResponse loginWithKakao(KakaoLoginRequest request) {
+        String kakaoId = kakaoOAuthService.getKakaoId(request.kakaoAccessToken());
+
+        boolean[] isNew = {false};
+        Member member = memberRepository.findByKakaoId(kakaoId)
+                .orElseGet(() -> {
+                    isNew[0] = true;
+                    return memberRepository.save(Member.builder().kakaoId(kakaoId).build());
+                });
+
+        return issueTokens(member, isNew[0]);
+    }
+
+    @Transactional(readOnly = true)
+    public TokenResponse refresh(RefreshRequest request) {
+        Claims claims = jwtProvider.parseRefreshToken(request.refreshToken());
+        Long memberId = ((Number) claims.get("mid")).longValue();
+        String jti = jwtProvider.extractJti(claims);
+
+        boolean exists = refreshTokenRepository
+                .findPublicIdByMemberIdAndJti(memberId, jti).isPresent();
+
+        if (!exists) {
+            log.warn("Refresh Token 재사용 공격 감지! memberId={}, jti={}", memberId, jti);
+            refreshTokenRepository.deleteAllByMemberId(memberId);
+            throw new InvalidTokenException(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
+        }
+
+        refreshTokenRepository.deleteByMemberIdAndJti(memberId, jti);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_TOKEN));
+
+        return issueTokens(member, null);
+    }
+
+    public void logout(Long memberId) {
+        refreshTokenRepository.deleteAllByMemberId(memberId);
+        log.info("로그아웃 완료 - memberId={}", memberId);
+    }
+
+    private TokenResponse issueTokens(Member member, Boolean isNewMember) {
+        String accessToken = jwtProvider.createAccessToken(member);
+        String refreshToken = jwtProvider.createRefreshToken(member);
+
+        Claims refreshClaims = jwtProvider.parseRefreshToken(refreshToken);
+        String jti = jwtProvider.extractJti(refreshClaims);
+
+        Duration ttl = Duration.ofSeconds(jwtProperties.refreshTokenExpiry());
+        refreshTokenRepository.save(member.getId(), jti, member.getPublicId(), ttl);
+
+        if (isNewMember == null) {
+            return TokenResponse.ofRefresh(accessToken, refreshToken, jwtProperties.accessTokenExpiry());
+        }
+        return TokenResponse.ofLogin(accessToken, refreshToken, jwtProperties.accessTokenExpiry(), isNewMember);
+    }
+}

--- a/src/main/java/com/linclean/auth/service/AuthService.java
+++ b/src/main/java/com/linclean/auth/service/AuthService.java
@@ -38,13 +38,12 @@ public class AuthService {
                 memberRepository.save(Member.builder().kakaoId(kakaoId).build()));
         boolean isNewMember = existing.isEmpty();
 
-        return issueTokens(member, isNewMember);
+        return issueTokensForLogin(member, isNewMember);
     }
 
-    @Transactional(readOnly = true)
     public TokenResponse refresh(RefreshRequest request) {
         Claims claims = jwtProvider.parseRefreshToken(request.refreshToken());
-        Long memberId = ((Number) claims.get("mid")).longValue();
+        Long memberId = jwtProvider.extractMemberId(claims);
         String jti = jwtProvider.extractJti(claims);
 
         boolean deleted = refreshTokenRepository
@@ -59,7 +58,7 @@ public class AuthService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_TOKEN));
 
-        return issueTokens(member, null);
+        return rotateTokens(member);
     }
 
     public void logout(Long memberId) {
@@ -67,7 +66,17 @@ public class AuthService {
         log.info("로그아웃 완료 - memberId={}", memberId);
     }
 
-    private TokenResponse issueTokens(Member member, Boolean isNewMember) {
+    private TokenResponse issueTokensForLogin(Member member, boolean isNewMember) {
+        String[] tokens = generateAndSaveTokens(member);
+        return TokenResponse.ofLogin(tokens[0], tokens[1], jwtProperties.accessTokenExpiry(), isNewMember);
+    }
+
+    private TokenResponse rotateTokens(Member member) {
+        String[] tokens = generateAndSaveTokens(member);
+        return TokenResponse.ofRefresh(tokens[0], tokens[1], jwtProperties.accessTokenExpiry());
+    }
+
+    private String[] generateAndSaveTokens(Member member) {
         String accessToken = jwtProvider.createAccessToken(member);
         String refreshToken = jwtProvider.createRefreshToken(member);
 
@@ -77,9 +86,6 @@ public class AuthService {
         Duration ttl = Duration.ofSeconds(jwtProperties.refreshTokenExpiry());
         refreshTokenRepository.save(member.getId(), jti, member.getPublicId(), ttl);
 
-        if (isNewMember == null) {
-            return TokenResponse.ofRefresh(accessToken, refreshToken, jwtProperties.accessTokenExpiry());
-        }
-        return TokenResponse.ofLogin(accessToken, refreshToken, jwtProperties.accessTokenExpiry(), isNewMember);
+        return new String[]{accessToken, refreshToken};
     }
 }

--- a/src/main/java/com/linclean/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/linclean/auth/service/KakaoOAuthService.java
@@ -1,0 +1,16 @@
+package com.linclean.auth.service;
+
+import com.linclean.auth.client.KakaoApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService {
+
+    private final KakaoApiClient kakaoApiClient;
+
+    public String getKakaoId(String kakaoAccessToken) {
+        return kakaoApiClient.getUserInfo(kakaoAccessToken).kakaoId();
+    }
+}

--- a/src/main/java/com/linclean/domain/member/entity/Member.java
+++ b/src/main/java/com/linclean/domain/member/entity/Member.java
@@ -26,7 +26,7 @@ public class Member extends BaseEntity {
     @Column(name = "public_id", nullable = false, unique = true, updatable = false)
     private UUID publicId;
 
-    @Column(name = "kakao_id", nullable = false, unique = true)
+    @Column(name = "kakao_id", nullable = false)
     private String kakaoId;
 
     @Column(name = "deleted_at")

--- a/src/main/java/com/linclean/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/linclean/domain/member/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.linclean.domain.member.repository;
+
+import com.linclean.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    // @SQLRestriction("deleted_at IS NULL") 덕분에 자동으로 활성 회원만 조회됨
+    Optional<Member> findByKakaoId(String kakaoId);
+}

--- a/src/main/java/com/linclean/global/config/AppConfig.java
+++ b/src/main/java/com/linclean/global/config/AppConfig.java
@@ -1,0 +1,9 @@
+package com.linclean.global.config;
+
+import com.linclean.auth.jwt.JwtProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(JwtProperties.class)
+public class AppConfig {}

--- a/src/main/java/com/linclean/global/config/RedisConfig.java
+++ b/src/main/java/com/linclean/global/config/RedisConfig.java
@@ -1,0 +1,11 @@
+package com.linclean.global.config;
+
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * spring-boot-starter-data-redis 자동 구성으로 StringRedisTemplate 등록됨.
+ * application.yml의 spring.data.redis.* 설정으로 연결.
+ * 운영 전환 시 Sentinel/Cluster 설정을 이 클래스에 추가.
+ */
+@Configuration
+public class RedisConfig {}

--- a/src/main/java/com/linclean/global/config/SecurityConfig.java
+++ b/src/main/java/com/linclean/global/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.linclean.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linclean.auth.jwt.JwtAuthenticationEntryPoint;
+import com.linclean.auth.jwt.JwtAuthenticationFilter;
+import com.linclean.auth.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/kakao/login",
+                                "/api/v1/auth/refresh"
+                        ).permitAll()
+                        .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(e ->
+                        e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtProvider, objectMapper),
+                        UsernamePasswordAuthenticationFilter.class
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/linclean/global/config/WebClientConfig.java
+++ b/src/main/java/com/linclean/global/config/WebClientConfig.java
@@ -1,0 +1,32 @@
+package com.linclean.global.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${kakao.api-base-url}")
+    private String kakaoApiBaseUrl;
+
+    @Bean
+    public WebClient kakaoWebClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2_000)
+                .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(3, TimeUnit.SECONDS)));
+
+        return WebClient.builder()
+                .baseUrl(kakaoApiBaseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/src/main/java/com/linclean/global/exception/ErrorCode.java
+++ b/src/main/java/com/linclean/global/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package com.linclean.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_001", "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 토큰입니다."),
+    REFRESH_TOKEN_REUSE_DETECTED(HttpStatus.UNAUTHORIZED, "AUTH_003", "Refresh Token 재사용이 감지되었습니다."),
+    INVALID_KAKAO_TOKEN(HttpStatus.UNAUTHORIZED, "KAKAO_001", "유효하지 않은 카카오 토큰입니다."),
+    KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "KAKAO_002", "카카오 서버 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/linclean/global/exception/ErrorResponse.java
+++ b/src/main/java/com/linclean/global/exception/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.linclean.global.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.Instant;
+
+public record ErrorResponse(
+        String code,
+        String message,
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        Instant timestamp
+) {
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), Instant.now());
+    }
+}

--- a/src/main/java/com/linclean/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/linclean/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package com.linclean.global.exception;
+
+import com.linclean.auth.exception.InvalidTokenException;
+import com.linclean.auth.exception.KakaoAuthException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidToken(InvalidTokenException e) {
+        log.debug("토큰 오류: {}", e.getMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(ErrorResponse.of(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(KakaoAuthException.class)
+    public ResponseEntity<ErrorResponse> handleKakaoAuth(KakaoAuthException e) {
+        log.warn("카카오 인증 오류: {}", e.getMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(ErrorResponse.of(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(fe -> fe.getDefaultMessage())
+                .orElse("요청 파라미터가 유효하지 않습니다.");
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse("VALIDATION_ERROR", message, Instant.now()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(Exception e) {
+        log.error("예상치 못한 오류 발생", e);
+        return ResponseEntity.internalServerError()
+                .body(new ErrorResponse("INTERNAL_ERROR", "서버 내부 오류가 발생했습니다.", Instant.now()));
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,1 +1,15 @@
-# 테스트 환경 DB, 로깅 설정 등을 여기에 추가하세요.
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+  data:
+    redis:
+      password: ""
+
+jwt:
+  secret: test-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm
+  access-token-expiry: 1800
+  refresh-token-expiry: 1209600
+
+kakao:
+  api-base-url: http://localhost:9999

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,8 +36,8 @@ server:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiry: 1800      # 30분 (초 단위)
-  refresh-token-expiry: 1209600  # 14일 (초 단위)
+  access-token-expiry: ${JWT_ACCESS_TOKEN_EXPIRY:1800}      # 30분 (초 단위)
+  refresh-token-expiry: ${JWT_REFRESH_TOKEN_EXPIRY:1209600} # 14일 (초 단위)
 
 kakao:
   api-base-url: https://kapi.kakao.com

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,11 @@ spring:
 
 server:
   port: ${API_PORT}
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiry: 1800      # 30분 (초 단위)
+  refresh-token-expiry: 1209600  # 14일 (초 단위)
+
+kakao:
+  api-base-url: https://kapi.kakao.com

--- a/src/main/resources/db/init.sql
+++ b/src/main/resources/db/init.sql
@@ -16,8 +16,7 @@ CREATE TABLE member (
                         updated_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
                         deleted_at      TIMESTAMPTZ,
 
-                        CONSTRAINT uq_member_public_id  UNIQUE (public_id),
-                        CONSTRAINT uq_member_kakao_id   UNIQUE (kakao_id)
+                        CONSTRAINT uq_member_public_id  UNIQUE (public_id)
 );
 
 -- ============================================================
@@ -186,3 +185,10 @@ CREATE TABLE notice (
                         created_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
                         updated_at      TIMESTAMPTZ     NOT NULL DEFAULT now()
 );
+
+-- ============================================================
+-- 활성 회원 기준 kakao_id 유니크 인덱스 (소프트 삭제 고려)
+-- 탈퇴 후 재가입 시 동일 kakao_id로 새 row 삽입 가능
+-- ============================================================
+CREATE UNIQUE INDEX uq_member_kakao_id_active
+    ON member (kakao_id) WHERE deleted_at IS NULL;

--- a/src/test/java/com/linclean/LincleanApiApplicationTests.java
+++ b/src/test/java/com/linclean/LincleanApiApplicationTests.java
@@ -2,9 +2,37 @@ package com.linclean;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
 class LincleanApiApplicationTests {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17")
+            .withDatabaseName("linclean_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/linclean/auth/client/KakaoApiClientTest.java
+++ b/src/test/java/com/linclean/auth/client/KakaoApiClientTest.java
@@ -1,0 +1,71 @@
+package com.linclean.auth.client;
+
+import com.linclean.auth.dto.response.KakaoUserResponse;
+import com.linclean.auth.exception.KakaoAuthException;
+import com.linclean.global.exception.ErrorCode;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.*;
+
+class KakaoApiClientTest {
+
+    private MockWebServer mockWebServer;
+    private KakaoApiClient kakaoApiClient;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        WebClient webClient = WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .build();
+        kakaoApiClient = new KakaoApiClient(webClient);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    @DisplayName("정상 응답 - 카카오 사용자 정보 반환")
+    void getUserInfo_success() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"id\": 123456789, \"connected_at\": \"2024-01-01T00:00:00Z\"}"));
+
+        KakaoUserResponse result = kakaoApiClient.getUserInfo("valid-token");
+
+        assertThat(result.id()).isEqualTo(123456789L);
+        assertThat(result.kakaoId()).isEqualTo("123456789");
+    }
+
+    @Test
+    @DisplayName("401 응답 - INVALID_KAKAO_TOKEN 예외")
+    void getUserInfo_401_throwsInvalidKakaoToken() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(401));
+
+        assertThatThrownBy(() -> kakaoApiClient.getUserInfo("invalid-token"))
+                .isInstanceOf(KakaoAuthException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_KAKAO_TOKEN);
+    }
+
+    @Test
+    @DisplayName("500 응답 - KAKAO_SERVER_ERROR 예외")
+    void getUserInfo_500_throwsKakaoServerError() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+        assertThatThrownBy(() -> kakaoApiClient.getUserInfo("some-token"))
+                .isInstanceOf(KakaoAuthException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.KAKAO_SERVER_ERROR);
+    }
+}

--- a/src/test/java/com/linclean/auth/client/KakaoApiClientTest.java
+++ b/src/test/java/com/linclean/auth/client/KakaoApiClientTest.java
@@ -68,4 +68,27 @@ class KakaoApiClientTest {
                 .isInstanceOf(KakaoAuthException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.KAKAO_SERVER_ERROR);
     }
+
+    @Test
+    @DisplayName("403 응답 - KAKAO_SERVER_ERROR 예외")
+    void getUserInfo_403_throwsKakaoServerError() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(403));
+
+        assertThatThrownBy(() -> kakaoApiClient.getUserInfo("some-token"))
+                .isInstanceOf(KakaoAuthException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.KAKAO_SERVER_ERROR);
+    }
+
+    @Test
+    @DisplayName("잘못된 JSON 응답 - KAKAO_SERVER_ERROR 예외")
+    void getUserInfo_invalidJson_throwsKakaoServerError() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{invalid json"));
+
+        assertThatThrownBy(() -> kakaoApiClient.getUserInfo("valid-token"))
+                .isInstanceOf(KakaoAuthException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.KAKAO_SERVER_ERROR);
+    }
 }

--- a/src/test/java/com/linclean/auth/jwt/JwtProviderTest.java
+++ b/src/test/java/com/linclean/auth/jwt/JwtProviderTest.java
@@ -1,0 +1,83 @@
+package com.linclean.auth.jwt;
+
+import com.linclean.auth.exception.InvalidTokenException;
+import com.linclean.domain.member.entity.Member;
+import com.linclean.global.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+class JwtProviderTest {
+
+    private static final String SECRET =
+            "test-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm";
+
+    private JwtProvider jwtProvider;
+    private Member testMember;
+
+    @BeforeEach
+    void setUp() {
+        jwtProvider = new JwtProvider(new JwtProperties(SECRET, 1800L, 1209600L));
+        testMember = Member.builder().kakaoId("12345678").build();
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(testMember, "publicId", UUID.randomUUID());
+    }
+
+    @Test
+    @DisplayName("Access Token 생성 및 파싱 성공")
+    void createAndParseAccessToken() {
+        String token = jwtProvider.createAccessToken(testMember);
+        Claims claims = jwtProvider.parseAccessToken(token);
+
+        assertThat(claims.getSubject()).isEqualTo(testMember.getPublicId().toString());
+        assertThat(((Number) claims.get("mid")).longValue()).isEqualTo(1L);
+        assertThat(claims.get("type", String.class)).isEqualTo("access");
+    }
+
+    @Test
+    @DisplayName("Refresh Token 생성 및 파싱 성공 - jti 포함")
+    void createAndParseRefreshToken() {
+        String token = jwtProvider.createRefreshToken(testMember);
+        Claims claims = jwtProvider.parseRefreshToken(token);
+
+        assertThat(claims.get("type", String.class)).isEqualTo("refresh");
+        assertThat(claims.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Refresh Token을 Access Token으로 파싱 시 INVALID_TOKEN")
+    void parseRefreshAsAccess_fails() {
+        String refreshToken = jwtProvider.createRefreshToken(testMember);
+
+        assertThatThrownBy(() -> jwtProvider.parseAccessToken(refreshToken))
+                .isInstanceOf(InvalidTokenException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN);
+    }
+
+    @Test
+    @DisplayName("위조된 토큰 파싱 시 INVALID_TOKEN")
+    void parseTampered_fails() {
+        String token = jwtProvider.createAccessToken(testMember) + "tampered";
+
+        assertThatThrownBy(() -> jwtProvider.parseAccessToken(token))
+                .isInstanceOf(InvalidTokenException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN);
+    }
+
+    @Test
+    @DisplayName("만료된 토큰 파싱 시 TOKEN_EXPIRED")
+    void parseExpired_fails() {
+        JwtProvider shortProvider = new JwtProvider(new JwtProperties(SECRET, 0L, 0L));
+        String token = shortProvider.createAccessToken(testMember);
+
+        assertThatThrownBy(() -> jwtProvider.parseAccessToken(token))
+                .isInstanceOf(InvalidTokenException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.TOKEN_EXPIRED);
+    }
+}

--- a/src/test/java/com/linclean/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/linclean/auth/service/AuthServiceIntegrationTest.java
@@ -1,0 +1,113 @@
+package com.linclean.auth.service;
+
+import com.linclean.auth.client.KakaoApiClient;
+import com.linclean.auth.dto.request.KakaoLoginRequest;
+import com.linclean.auth.dto.request.RefreshRequest;
+import com.linclean.auth.dto.response.KakaoUserResponse;
+import com.linclean.auth.dto.response.TokenResponse;
+import com.linclean.auth.exception.InvalidTokenException;
+import com.linclean.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+class AuthServiceIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17")
+            .withDatabaseName("linclean_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @Autowired AuthService authService;
+    @MockBean KakaoApiClient kakaoApiClient;
+
+    @Test
+    @DisplayName("신규 회원 카카오 로그인 - isNewMember=true")
+    void loginWithKakao_newMember() {
+        given(kakaoApiClient.getUserInfo(anyString()))
+                .willReturn(new KakaoUserResponse(999L, "2024-01-01T00:00:00Z"));
+
+        TokenResponse response = authService.loginWithKakao(
+                new KakaoLoginRequest("valid-kakao-token"));
+
+        assertThat(response.isNewMember()).isTrue();
+        assertThat(response.accessToken()).isNotBlank();
+        assertThat(response.refreshToken()).isNotBlank();
+        assertThat(response.tokenType()).isEqualTo("Bearer");
+    }
+
+    @Test
+    @DisplayName("기존 회원 카카오 로그인 - isNewMember=false")
+    void loginWithKakao_existingMember() {
+        given(kakaoApiClient.getUserInfo(anyString()))
+                .willReturn(new KakaoUserResponse(888L, "2024-01-01T00:00:00Z"));
+
+        authService.loginWithKakao(new KakaoLoginRequest("token1"));
+        TokenResponse response = authService.loginWithKakao(new KakaoLoginRequest("token2"));
+
+        assertThat(response.isNewMember()).isFalse();
+    }
+
+    @Test
+    @DisplayName("RTR - 정상 재발급: 새 RT 발급됨")
+    void refresh_success() {
+        given(kakaoApiClient.getUserInfo(anyString()))
+                .willReturn(new KakaoUserResponse(777L, "2024-01-01T00:00:00Z"));
+
+        TokenResponse loginResponse = authService.loginWithKakao(
+                new KakaoLoginRequest("token"));
+        TokenResponse refreshResponse = authService.refresh(
+                new RefreshRequest(loginResponse.refreshToken()));
+
+        assertThat(refreshResponse.accessToken()).isNotBlank();
+        assertThat(refreshResponse.refreshToken())
+                .isNotEqualTo(loginResponse.refreshToken());
+    }
+
+    @Test
+    @DisplayName("RTR - 같은 RT 재사용 시 REFRESH_TOKEN_REUSE_DETECTED")
+    void refresh_reuseDetected() {
+        given(kakaoApiClient.getUserInfo(anyString()))
+                .willReturn(new KakaoUserResponse(666L, "2024-01-01T00:00:00Z"));
+
+        TokenResponse loginResponse = authService.loginWithKakao(
+                new KakaoLoginRequest("token"));
+        String oldRefreshToken = loginResponse.refreshToken();
+
+        authService.refresh(new RefreshRequest(oldRefreshToken));
+
+        assertThatThrownBy(() -> authService.refresh(new RefreshRequest(oldRefreshToken)))
+                .isInstanceOf(InvalidTokenException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
+    }
+}


### PR DESCRIPTION
# 요약

프론트 주도 방식의 카카오 소셜 로그인을 구현합니다.
클라이언트가 카카오 SDK로 획득한 access_token을 서버에 전달하면, 서버가 카카오 API로 사용자 정보를 조회하고 자체 JWT를 발급합니다.
Refresh Token은 RTR(Refresh Token Rotation) 방식으로 Redis에 관리하여 재사용 공격을 탐지합니다.

## 1. DB 스키마 — src/main/resources/db/init.sql

e0b7b6c [Feat] kakao_id partial unique index + MemberRepository

- `CONSTRAINT uq_member_kakao_id UNIQUE` 제거 → partial unique index(`WHERE deleted_at IS NULL`)로 교체
- soft delete 후 동일 kakao_id로 재가입 가능하도록 DB 레벨 보장

## 2. JWT 인프라 + Spring Security — auth/jwt/, global/config/

87e2e5f [Feat] JWT 인프라 + Spring Security 6.x 설정

- JJWT 0.12.6 신규 API 기반 `JwtProvider` 구현 (access/refresh 토큰 타입 클레임으로 구분)
- `JwtAuthenticationFilter`: OncePerRequestFilter, Spring Bean 등록 없이 SecurityConfig에서 직접 주입
- Spring Security 6.x `SecurityFilterChain` 빈 방식, STATELESS 세션, CSRF 비활성화

e394434 [Fix] JwtAuthenticationFilter ClassCastException 예외 처리 추가

- `mid` 클레임 캐스팅 실패 시 `INVALID_TOKEN` 반환

## 3. WebClient 기반 카카오 API 클라이언트

d2d5fe6 [Feat] WebClient 기반 KakaoApiClient 구현 + MockWebServer 테스트

- Reactor Netty 커넥트 2초 / 읽기 3초 타임아웃
- 401 → `INVALID_KAKAO_TOKEN`, 5xx → `KAKAO_SERVER_ERROR`, 기타 → `KAKAO_SERVER_ERROR`

690fe41 [Test] KakaoApiClientTest 4xx/잘못된JSON 케이스 추가

## 4. Redis RTR RefreshTokenRepository

b74d3ab [Feat] Redis RTR 패턴 RefreshTokenRepository 구현

- Key: `refresh:{memberId}:{jti}`, SCAN 기반 `deleteAllByMemberId`
- 원자적 GETDEL(`getAndDelete`)로 재사용 감지 레이스 컨디션 방지

## 5. AuthController + AuthService

7ea4ce8 [Feat] AuthController + AuthService + RTR 로그인/재발급/로그아웃 구현

- `POST /api/v1/auth/kakao/login` — 신규/기존 회원 자동 구분, `isNewMember` 응답
- `POST /api/v1/auth/refresh` — RTR 재발급, 재사용 시 전체 RT 삭제 후 예외
- `POST /api/v1/auth/logout` — 해당 멤버 RT 전체 삭제

59611f1 [Fix] RTR 원자적 GETDEL + isNewMember Optional 리팩토링
21972d2 [Test] LincleanApiApplicationTests TestContainers + test 프로파일 적용
833a47f [Chore] JWT 토큰 만료시간 환경변수로 분리
10bc2b4 [Refactor] issueTokens 분리 + readOnly 제거 + extractMemberId 응집

- `issueTokensForLogin` / `rotateTokens`로 분리, `extractMemberId(Claims)` JwtProvider에 응집

## 5. 테스트 코드 통과
<img width="480" height="454" alt="스크린샷 2026-04-27 오후 1 45 41" src="https://github.com/user-attachments/assets/18f24d5f-8bac-468d-b51f-efbe2dfdf076" />

## 6. 테스트

### 1. 로그인

<img width="914" height="444" alt="image" src="https://github.com/user-attachments/assets/59c0868b-e8aa-42b0-928f-ab1d160e2f57" />

테스트용 토큰 발급

~~~
curl -s -X POST http://localhost:8080/api/v1/auth/kakao/login -H "Content-Type: application/json" -d '{"kakaoAccessToken":"토큰"}' | tee /tmp/login.json
{"accessToken":"AT","refreshToken":"RT":false}%
~~~

~~~
curl -X POST http://localhost:8080/api/v1/auth/refresh -H "Content-Type: application/json" -d "{\"refreshToken\":\"$RT\"}"
{"accessToken":"AT","refreshToken":"RT","tokenType":"Bearer","expiresIn":1800,"isNewMember":null}%
~~~

### 2. Refresh 호출
~~~
curl -X POST http://localhost:8080/api/v1/auth/refresh -H "Content-Type: application/json" -d "{\"refreshToken\":\"$RT\"}"
{"code":"AUTH_003","message":"Refresh Token 재사용이 감지되었습니다.","timestamp":"2026-04-27T05:11:55.821424Z"}%
~~~

### 3. 같은 RT 재사용 (재사용 감지 확인)
~~~
curl -X POST http://localhost:8080/api/v1/auth/refresh -H "Content-Type: application/json" -d "{\"refreshToken\":\"$RT\"}"
{"code":"AUTH_003","message":"Refresh Token 재사용이 감지되었습니다.","timestamp":"2026-04-27T05:11:55.821424Z"}%
~~~


### 4. 로그아웃
~~~
curl -i -X POST http://localhost:8080/api/v1/auth/logout -H "Authorization: Bearer $AT"
HTTP/1.1 204
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Date: Mon, 27 Apr 2026 05:13:40 GMT
~~~

서버 로그 사진

<img width="1222" height="91" alt="image" src="https://github.com/user-attachments/assets/f31a98ff-00a9-4133-b2fb-048059d14153" />


# 연관 이슈 및 Close 할 이슈 작성

#7

close #7

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?