### PR TITLE
[FEATURE] 분석 API 개발

### DIFF
--- a/src/main/java/com/linclean/domain/analysis/controller/AnalysisCallbackController.java
+++ b/src/main/java/com/linclean/domain/analysis/controller/AnalysisCallbackController.java
@@ -1,0 +1,27 @@
+package com.linclean.domain.analysis.controller;
+
+import com.linclean.domain.analysis.dto.callback.AnalysisResultCallback;
+import com.linclean.domain.analysis.dto.callback.CallbackReceivedResponse;
+import com.linclean.domain.analysis.service.AnalysisCallbackService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+public class AnalysisCallbackController {
+
+    private final AnalysisCallbackService callbackService;
+
+    @PostMapping("/analysis-result")
+    public ResponseEntity<CallbackReceivedResponse> receiveResult(
+            @Valid @RequestBody AnalysisResultCallback callback) {
+        callbackService.handleCallback(callback);
+        return ResponseEntity.ok(CallbackReceivedResponse.ok());
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/linclean/domain/analysis/controller/AnalysisController.java
@@ -1,0 +1,43 @@
+package com.linclean.domain.analysis.controller;
+
+import com.linclean.auth.jwt.MemberPrincipal;
+import com.linclean.domain.analysis.dto.request.AnalysisRequest;
+import com.linclean.domain.analysis.dto.response.AnalysisResponse;
+import com.linclean.domain.analysis.service.AnalysisService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/analyses")
+@RequiredArgsConstructor
+public class AnalysisController {
+
+    private final AnalysisService analysisService;
+
+    @PostMapping
+    public ResponseEntity<AnalysisResponse> requestAnalysis(
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @Valid @RequestBody AnalysisRequest request) {
+        AnalysisResponse response = analysisService.requestAnalysis(principal.memberId(), request);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
+    }
+
+    @GetMapping("/{analysisId}")
+    public ResponseEntity<AnalysisResponse> getAnalysis(
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @PathVariable UUID analysisId) {
+        AnalysisResponse response = analysisService.getAnalysis(principal.memberId(), analysisId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/dto/callback/AnalysisResultCallback.java
+++ b/src/main/java/com/linclean/domain/analysis/dto/callback/AnalysisResultCallback.java
@@ -1,0 +1,36 @@
+package com.linclean.domain.analysis.dto.callback;
+
+import com.linclean.domain.analysis.entity.AnalysisStatus;
+import com.linclean.domain.analysis.entity.StagesDto;
+import com.linclean.domain.analysis.entity.Verdict;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record AnalysisResultCallback(
+        @NotNull UUID analysisId,
+        @NotNull UUID requestId,
+        @NotNull AnalysisStatus status,
+        @NotNull String originalUrl,
+
+        // succeeded fields (nullable)
+        String finalUrl,
+        Verdict verdict,
+        Integer score,
+        List<ReasonItem> reasons,
+        StagesDto stages,
+        String summary,
+
+        // failed fields (nullable)
+        ErrorInfo error,
+
+        // common (required)
+        @NotNull String engineVersion,
+        @NotNull Instant analyzedAt,
+        @NotNull Integer elapsedMs
+) {
+    public record ReasonItem(String code, int stage, int weight, String message) {}
+    public record ErrorInfo(String code, Integer stage, String message) {}
+}

--- a/src/main/java/com/linclean/domain/analysis/dto/callback/AnalysisResultCallback.java
+++ b/src/main/java/com/linclean/domain/analysis/dto/callback/AnalysisResultCallback.java
@@ -1,7 +1,7 @@
 package com.linclean.domain.analysis.dto.callback;
 
 import com.linclean.domain.analysis.entity.AnalysisStatus;
-import com.linclean.domain.analysis.entity.StagesDto;
+import com.linclean.domain.analysis.entity.Stages;
 import com.linclean.domain.analysis.entity.Verdict;
 import jakarta.validation.constraints.NotNull;
 
@@ -20,7 +20,7 @@ public record AnalysisResultCallback(
         Verdict verdict,
         Integer score,
         List<ReasonItem> reasons,
-        StagesDto stages,
+        Stages stages,
         String summary,
 
         // failed fields (nullable)

--- a/src/main/java/com/linclean/domain/analysis/dto/callback/AnalysisResultCallback.java
+++ b/src/main/java/com/linclean/domain/analysis/dto/callback/AnalysisResultCallback.java
@@ -3,12 +3,15 @@ package com.linclean.domain.analysis.dto.callback;
 import com.linclean.domain.analysis.entity.AnalysisStatus;
 import com.linclean.domain.analysis.entity.Stages;
 import com.linclean.domain.analysis.entity.Verdict;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
+@ValidCallbackFields
 public record AnalysisResultCallback(
         @NotNull UUID analysisId,
         @NotNull UUID requestId,
@@ -18,7 +21,7 @@ public record AnalysisResultCallback(
         // succeeded fields (nullable)
         String finalUrl,
         Verdict verdict,
-        Integer score,
+        @Min(0) @Max(100) Integer score,
         List<ReasonItem> reasons,
         Stages stages,
         String summary,
@@ -31,6 +34,6 @@ public record AnalysisResultCallback(
         @NotNull Instant analyzedAt,
         @NotNull Integer elapsedMs
 ) {
-    public record ReasonItem(String code, int stage, int weight, String message) {}
+    public record ReasonItem(String code, @Min(1) @Max(4) int stage, int weight, String message) {}
     public record ErrorInfo(String code, Integer stage, String message) {}
 }

--- a/src/main/java/com/linclean/domain/analysis/dto/callback/CallbackFieldsValidator.java
+++ b/src/main/java/com/linclean/domain/analysis/dto/callback/CallbackFieldsValidator.java
@@ -1,0 +1,25 @@
+package com.linclean.domain.analysis.dto.callback;
+
+import com.linclean.domain.analysis.entity.AnalysisStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class CallbackFieldsValidator
+        implements ConstraintValidator<ValidCallbackFields, AnalysisResultCallback> {
+
+    @Override
+    public boolean isValid(AnalysisResultCallback dto, ConstraintValidatorContext ctx) {
+        if (dto.status() == AnalysisStatus.SUCCEEDED) {
+            return dto.finalUrl() != null
+                    && dto.verdict() != null
+                    && dto.score() != null
+                    && dto.stages() != null
+                    && dto.reasons() != null
+                    && dto.summary() != null;
+        }
+        if (dto.status() == AnalysisStatus.FAILED) {
+            return dto.error() != null;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/dto/callback/CallbackReceivedResponse.java
+++ b/src/main/java/com/linclean/domain/analysis/dto/callback/CallbackReceivedResponse.java
@@ -1,0 +1,7 @@
+package com.linclean.domain.analysis.dto.callback;
+
+public record CallbackReceivedResponse(boolean received) {
+    public static CallbackReceivedResponse ok() {
+        return new CallbackReceivedResponse(true);
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/dto/callback/ValidCallbackFields.java
+++ b/src/main/java/com/linclean/domain/analysis/dto/callback/ValidCallbackFields.java
@@ -1,0 +1,18 @@
+package com.linclean.domain.analysis.dto.callback;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = CallbackFieldsValidator.class)
+public @interface ValidCallbackFields {
+    String message() default "SUCCEEDED 콜백에는 finalUrl, verdict, score, reasons, stages, summary가 필요합니다. FAILED 콜백에는 error가 필요합니다";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/linclean/domain/analysis/dto/request/AnalysisRequest.java
+++ b/src/main/java/com/linclean/domain/analysis/dto/request/AnalysisRequest.java
@@ -1,0 +1,10 @@
+package com.linclean.domain.analysis.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AnalysisRequest(
+        @NotBlank(message = "URL은 필수입니다.")
+        @Size(max = 2048, message = "URL은 2048자를 초과할 수 없습니다.")
+        String url
+) {}

--- a/src/main/java/com/linclean/domain/analysis/dto/response/AnalysisResponse.java
+++ b/src/main/java/com/linclean/domain/analysis/dto/response/AnalysisResponse.java
@@ -1,0 +1,81 @@
+package com.linclean.domain.analysis.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.linclean.domain.analysis.entity.Analysis;
+import com.linclean.domain.analysis.entity.AnalysisReason;
+import com.linclean.domain.analysis.entity.AnalysisStatus;
+import com.linclean.domain.analysis.entity.Verdict;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AnalysisResponse {
+
+    private final UUID analysisId;
+    private final AnalysisStatus status;
+
+    private final String originalUrl;
+    private final String finalUrl;
+    private final Verdict verdict;
+    private final Integer score;
+    private final String summary;
+    private final List<ReasonDto> reasons;
+    private final Instant analyzedAt;
+    private final Integer elapsedMs;
+
+    private final String errorCode;
+    private final Integer errorStage;
+    private final String errorMessage;
+
+    public static AnalysisResponse forQueued(UUID analysisId) {
+        return new AnalysisResponse(
+                analysisId, AnalysisStatus.QUEUED,
+                null, null, null, null, null, null, null, null,
+                null, null, null
+        );
+    }
+
+    public static AnalysisResponse forSucceeded(Analysis analysis, List<AnalysisReason> reasons) {
+        return new AnalysisResponse(
+                analysis.getAnalysisId(), AnalysisStatus.SUCCEEDED,
+                analysis.getOriginalUrl(), analysis.getFinalUrl(),
+                analysis.getVerdict(), analysis.getScore(), analysis.getSummary(),
+                reasons.stream().map(ReasonDto::from).toList(),
+                analysis.getAnalyzedAt(), analysis.getElapsedMs(),
+                null, null, null
+        );
+    }
+
+    public static AnalysisResponse forFailed(Analysis analysis) {
+        return new AnalysisResponse(
+                analysis.getAnalysisId(), AnalysisStatus.FAILED,
+                analysis.getOriginalUrl(), null, null, null, null, null, null, null,
+                analysis.getErrorCode(), analysis.getErrorStage(), analysis.getErrorMessage()
+        );
+    }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class ReasonDto {
+        private final String code;
+        private final int stage;
+        private final int weight;
+        private final String message;
+
+        public static ReasonDto from(AnalysisReason reason) {
+            return new ReasonDto(
+                    reason.getCode(),
+                    reason.getStage(),
+                    reason.getWeight(),
+                    reason.getMessage()
+            );
+        }
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/entity/Analysis.java
+++ b/src/main/java/com/linclean/domain/analysis/entity/Analysis.java
@@ -25,6 +25,9 @@ import java.util.UUID;
 @Builder
 public class Analysis extends BaseAuditEntity {
 
+    @Version
+    private Long version;
+
     @Id
     @UuidGenerator(style = UuidGenerator.Style.TIME)
     @Column(name = "analysis_id")
@@ -82,4 +85,30 @@ public class Analysis extends BaseAuditEntity {
 
     @Column(name = "last_checked_at")
     private Instant lastCheckedAt;
+
+    public void updateToSucceeded(
+            String finalUrl, Verdict verdict, Integer score, String summary,
+            StagesDto stages, String engineVersion, Instant analyzedAt, Integer elapsedMs) {
+        this.status = AnalysisStatus.SUCCEEDED;
+        this.finalUrl = finalUrl;
+        this.verdict = verdict;
+        this.score = score;
+        this.summary = summary;
+        this.stages = stages;
+        this.engineVersion = engineVersion;
+        this.analyzedAt = analyzedAt;
+        this.elapsedMs = elapsedMs;
+    }
+
+    public void updateToFailed(
+            String errorCode, Integer errorStage, String errorMessage,
+            String engineVersion, Instant analyzedAt, Integer elapsedMs) {
+        this.status = AnalysisStatus.FAILED;
+        this.errorCode = errorCode;
+        this.errorStage = errorStage;
+        this.errorMessage = errorMessage;
+        this.engineVersion = engineVersion;
+        this.analyzedAt = analyzedAt;
+        this.elapsedMs = elapsedMs;
+    }
 }

--- a/src/main/java/com/linclean/domain/analysis/entity/Analysis.java
+++ b/src/main/java/com/linclean/domain/analysis/entity/Analysis.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.type.SqlTypes;
+import org.springframework.util.Assert;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -89,6 +90,11 @@ public class Analysis extends BaseAuditEntity {
     public void updateToSucceeded(
             String finalUrl, Verdict verdict, Integer score, String summary,
             Stages stages, String engineVersion, Instant analyzedAt, Integer elapsedMs) {
+        Assert.notNull(finalUrl, "SUCCEEDED 상태 전환에는 finalUrl이 필요합니다");
+        Assert.notNull(verdict, "SUCCEEDED 상태 전환에는 verdict가 필요합니다");
+        Assert.notNull(score, "SUCCEEDED 상태 전환에는 score가 필요합니다");
+        Assert.notNull(stages, "SUCCEEDED 상태 전환에는 stages가 필요합니다");
+        Assert.notNull(summary, "SUCCEEDED 상태 전환에는 summary가 필요합니다");
         this.status = AnalysisStatus.SUCCEEDED;
         this.finalUrl = finalUrl;
         this.verdict = verdict;

--- a/src/main/java/com/linclean/domain/analysis/entity/Analysis.java
+++ b/src/main/java/com/linclean/domain/analysis/entity/Analysis.java
@@ -60,7 +60,7 @@ public class Analysis extends BaseAuditEntity {
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "stages", columnDefinition = "jsonb")
-    private StagesDto stages;
+    private Stages stages;
 
     @Column(name = "error_code", length = 100)
     private String errorCode;
@@ -88,7 +88,7 @@ public class Analysis extends BaseAuditEntity {
 
     public void updateToSucceeded(
             String finalUrl, Verdict verdict, Integer score, String summary,
-            StagesDto stages, String engineVersion, Instant analyzedAt, Integer elapsedMs) {
+            Stages stages, String engineVersion, Instant analyzedAt, Integer elapsedMs) {
         this.status = AnalysisStatus.SUCCEEDED;
         this.finalUrl = finalUrl;
         this.verdict = verdict;

--- a/src/main/java/com/linclean/domain/analysis/entity/Stages.java
+++ b/src/main/java/com/linclean/domain/analysis/entity/Stages.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-public class StagesDto {
+public class Stages {
 
     private ExternalDbStage externalDb;
     private UnchainStage unchain;

--- a/src/main/java/com/linclean/domain/analysis/entity/StagesDto.java
+++ b/src/main/java/com/linclean/domain/analysis/entity/StagesDto.java
@@ -1,11 +1,14 @@
 package com.linclean.domain.analysis.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class StagesDto {
 
@@ -15,27 +18,33 @@ public class StagesDto {
     private ContentAnalysisStage contentAnalysis;
 
     @Getter
+    @Setter
     @NoArgsConstructor
     public static class ExternalDbStage {
         private GsbResult gsb;
         private UrlHausResult urlhaus;
 
         @Getter
+        @Setter
         @NoArgsConstructor
         public static class GsbResult {
+            @JsonProperty("isThreat")
             private boolean isThreat;
             private List<String> matchedTypes;
         }
 
         @Getter
+        @Setter
         @NoArgsConstructor
         public static class UrlHausResult {
+            @JsonProperty("isThreat")
             private boolean isThreat;
             private String host;
         }
     }
 
     @Getter
+    @Setter
     @NoArgsConstructor
     public static class UnchainStage {
         private int hops;
@@ -43,23 +52,27 @@ public class StagesDto {
     }
 
     @Getter
+    @Setter
     @NoArgsConstructor
     public static class DomainHeuristicStage {
         private RdapInfo rdap;
         private List<String> signals;
 
         @Getter
+        @Setter
         @NoArgsConstructor
         public static class RdapInfo {
             private String domain;
             private String registrar;
             private String createdDate;
             private int domainAgeDays;
+            @JsonProperty("isNewDomain")
             private boolean isNewDomain;
         }
     }
 
     @Getter
+    @Setter
     @NoArgsConstructor
     public static class ContentAnalysisStage {
         private boolean fetched;

--- a/src/main/java/com/linclean/domain/analysis/exception/AnalysisException.java
+++ b/src/main/java/com/linclean/domain/analysis/exception/AnalysisException.java
@@ -1,0 +1,15 @@
+package com.linclean.domain.analysis.exception;
+
+import com.linclean.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AnalysisException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AnalysisException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/repository/AnalysisReasonRepository.java
+++ b/src/main/java/com/linclean/domain/analysis/repository/AnalysisReasonRepository.java
@@ -1,0 +1,11 @@
+package com.linclean.domain.analysis.repository;
+
+import com.linclean.domain.analysis.entity.AnalysisReason;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AnalysisReasonRepository extends JpaRepository<AnalysisReason, Long> {
+    List<AnalysisReason> findAllByAnalysis_AnalysisId(UUID analysisId);
+}

--- a/src/main/java/com/linclean/domain/analysis/repository/AnalysisRepository.java
+++ b/src/main/java/com/linclean/domain/analysis/repository/AnalysisRepository.java
@@ -1,0 +1,9 @@
+package com.linclean.domain.analysis.repository;
+
+import com.linclean.domain.analysis.entity.Analysis;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface AnalysisRepository extends JpaRepository<Analysis, UUID> {
+}

--- a/src/main/java/com/linclean/domain/analysis/service/AnalysisAsyncRunner.java
+++ b/src/main/java/com/linclean/domain/analysis/service/AnalysisAsyncRunner.java
@@ -1,0 +1,67 @@
+package com.linclean.domain.analysis.service;
+
+import com.linclean.domain.analysis.entity.AnalysisStatus;
+import com.linclean.domain.analysis.repository.AnalysisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalysisAsyncRunner {
+
+    private final AnalysisRepository analysisRepository;
+    private final WebClient analysisEngineWebClient;
+
+    @Value("${internal.api-key}")
+    private String internalApiKey;
+
+    @Async("analysisTaskExecutor")
+    @Transactional
+    public void run(UUID analysisId, String originalUrl, UUID requestId) {
+        try {
+            analysisEngineWebClient.post()
+                    .uri("/api/v1/analyze")
+                    .header("X-Internal-Api-Key", internalApiKey)
+                    .header("X-Request-ID", requestId.toString())
+                    .bodyValue(Map.of(
+                            "analysisId", analysisId.toString(),
+                            "url", originalUrl
+                    ))
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block();
+
+            log.info("분석 위임 완료 - analysisId={}", analysisId);
+
+        } catch (WebClientResponseException e) {
+            log.error("FastAPI 호출 실패 - analysisId={}, status={}, body={}",
+                    analysisId, e.getStatusCode(), e.getResponseBodyAsString());
+            markFailed(analysisId, "ENGINE_REQUEST_FAILED",
+                    "분석 엔진 호출 실패: " + e.getStatusCode());
+
+        } catch (Exception e) {
+            log.error("FastAPI 호출 중 예외 - analysisId={}", analysisId, e);
+            markFailed(analysisId, "ENGINE_REQUEST_ERROR", "분석 엔진 연결 오류");
+        }
+    }
+
+    private void markFailed(UUID analysisId, String errorCode, String errorMessage) {
+        analysisRepository.findById(analysisId).ifPresent(analysis -> {
+            if (analysis.getStatus() == AnalysisStatus.QUEUED) {
+                analysis.updateToFailed(errorCode, null, errorMessage,
+                        null, Instant.now(), null);
+            }
+        });
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/service/AnalysisCallbackService.java
+++ b/src/main/java/com/linclean/domain/analysis/service/AnalysisCallbackService.java
@@ -70,18 +70,16 @@ public class AnalysisCallbackService {
                 callback.elapsedMs()
         );
 
-        if (callback.reasons() != null) {
-            List<AnalysisReason> reasons = callback.reasons().stream()
-                    .map(r -> AnalysisReason.builder()
-                            .analysis(analysis)
-                            .code(r.code())
-                            .stage(r.stage())
-                            .weight(r.weight())
-                            .message(r.message())
-                            .build())
-                    .toList();
-            analysisReasonRepository.saveAll(reasons);
-        }
+        List<AnalysisReason> reasons = callback.reasons().stream()
+                .map(r -> AnalysisReason.builder()
+                        .analysis(analysis)
+                        .code(r.code())
+                        .stage(r.stage())
+                        .weight(r.weight())
+                        .message(r.message())
+                        .build())
+                .toList();
+        analysisReasonRepository.saveAll(reasons);
     }
 
     private void applyFailed(Analysis analysis, AnalysisResultCallback callback) {

--- a/src/main/java/com/linclean/domain/analysis/service/AnalysisCallbackService.java
+++ b/src/main/java/com/linclean/domain/analysis/service/AnalysisCallbackService.java
@@ -1,0 +1,95 @@
+package com.linclean.domain.analysis.service;
+
+import com.linclean.domain.analysis.dto.callback.AnalysisResultCallback;
+import com.linclean.domain.analysis.entity.Analysis;
+import com.linclean.domain.analysis.entity.AnalysisReason;
+import com.linclean.domain.analysis.entity.AnalysisStatus;
+import com.linclean.domain.analysis.repository.AnalysisReasonRepository;
+import com.linclean.domain.analysis.repository.AnalysisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalysisCallbackService {
+
+    private final AnalysisRepository analysisRepository;
+    private final AnalysisReasonRepository analysisReasonRepository;
+
+    @Transactional
+    public void handleCallback(AnalysisResultCallback callback) {
+        Analysis analysis = analysisRepository.findById(callback.analysisId())
+                .orElseGet(() -> {
+                    log.warn("콜백 수신 - 존재하지 않는 analysisId={}", callback.analysisId());
+                    return null;
+                });
+
+        if (analysis == null) {
+            return;
+        }
+
+        if (analysis.getStatus() != AnalysisStatus.QUEUED) {
+            log.info("중복 콜백 무시 - analysisId={}, currentStatus={}",
+                    callback.analysisId(), analysis.getStatus());
+            return;
+        }
+
+        if (callback.status() == AnalysisStatus.SUCCEEDED) {
+            applySucceeded(analysis, callback);
+        } else if (callback.status() == AnalysisStatus.FAILED) {
+            applyFailed(analysis, callback);
+        } else {
+            log.warn("알 수 없는 콜백 status - analysisId={}, status={}",
+                    callback.analysisId(), callback.status());
+            return;
+        }
+
+        log.info("콜백 처리 완료 - analysisId={}, status={}", callback.analysisId(), callback.status());
+    }
+
+    private void applySucceeded(Analysis analysis, AnalysisResultCallback callback) {
+        analysis.updateToSucceeded(
+                callback.finalUrl(),
+                callback.verdict(),
+                callback.score(),
+                callback.summary(),
+                callback.stages(),
+                callback.engineVersion(),
+                callback.analyzedAt(),
+                callback.elapsedMs()
+        );
+
+        if (callback.reasons() != null) {
+            List<AnalysisReason> reasons = callback.reasons().stream()
+                    .map(r -> AnalysisReason.builder()
+                            .analysis(analysis)
+                            .code(r.code())
+                            .stage(r.stage())
+                            .weight(r.weight())
+                            .message(r.message())
+                            .build())
+                    .toList();
+            analysisReasonRepository.saveAll(reasons);
+        }
+    }
+
+    private void applyFailed(Analysis analysis, AnalysisResultCallback callback) {
+        String errorCode = null;
+        Integer errorStage = null;
+        String errorMessage = null;
+
+        if (callback.error() != null) {
+            errorCode = callback.error().code();
+            errorStage = callback.error().stage();
+            errorMessage = callback.error().message();
+        }
+
+        analysis.updateToFailed(errorCode, errorStage, errorMessage,
+                callback.engineVersion(), callback.analyzedAt(), callback.elapsedMs());
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/service/AnalysisCallbackService.java
+++ b/src/main/java/com/linclean/domain/analysis/service/AnalysisCallbackService.java
@@ -33,6 +33,12 @@ public class AnalysisCallbackService {
             return;
         }
 
+        if (!analysis.getRequestId().equals(callback.requestId())) {
+            log.warn("콜백 requestId 불일치 - analysisId={}, expected={}, actual={}",
+                    callback.analysisId(), analysis.getRequestId(), callback.requestId());
+            return;
+        }
+
         if (analysis.getStatus() != AnalysisStatus.QUEUED) {
             log.info("중복 콜백 무시 - analysisId={}, currentStatus={}",
                     callback.analysisId(), analysis.getStatus());

--- a/src/main/java/com/linclean/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/com/linclean/domain/analysis/service/AnalysisService.java
@@ -1,0 +1,77 @@
+package com.linclean.domain.analysis.service;
+
+import com.linclean.domain.analysis.dto.request.AnalysisRequest;
+import com.linclean.domain.analysis.dto.response.AnalysisResponse;
+import com.linclean.domain.analysis.entity.Analysis;
+import com.linclean.domain.analysis.entity.AnalysisReason;
+import com.linclean.domain.analysis.exception.AnalysisException;
+import com.linclean.domain.analysis.repository.AnalysisReasonRepository;
+import com.linclean.domain.analysis.repository.AnalysisRepository;
+import com.linclean.domain.member.entity.Member;
+import com.linclean.domain.member.repository.MemberRepository;
+import com.linclean.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AnalysisService {
+
+    private final AnalysisRepository analysisRepository;
+    private final AnalysisReasonRepository analysisReasonRepository;
+    private final MemberRepository memberRepository;
+    private final AnalysisAsyncRunner asyncRunner;
+
+    @Transactional
+    public AnalysisResponse requestAnalysis(Long memberId, AnalysisRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AnalysisException(ErrorCode.MEMBER_NOT_FOUND));
+
+        UUID requestId = UUID.randomUUID();
+
+        Analysis analysis = Analysis.builder()
+                .member(member)
+                .originalUrl(request.url())
+                .requestId(requestId)
+                .build();
+
+        Analysis saved = analysisRepository.save(analysis);
+        UUID savedAnalysisId = saved.getAnalysisId();
+        String savedUrl = saved.getOriginalUrl();
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                asyncRunner.run(savedAnalysisId, savedUrl, requestId);
+            }
+        });
+
+        return AnalysisResponse.forQueued(saved.getAnalysisId());
+    }
+
+    @Transactional(readOnly = true)
+    public AnalysisResponse getAnalysis(Long memberId, UUID analysisId) {
+        Analysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new AnalysisException(ErrorCode.ANALYSIS_NOT_FOUND));
+
+        if (!analysis.getMember().getId().equals(memberId)) {
+            throw new AnalysisException(ErrorCode.ANALYSIS_FORBIDDEN);
+        }
+
+        return switch (analysis.getStatus()) {
+            case QUEUED -> AnalysisResponse.forQueued(analysisId);
+            case SUCCEEDED -> {
+                List<AnalysisReason> reasons =
+                        analysisReasonRepository.findAllByAnalysis_AnalysisId(analysisId);
+                yield AnalysisResponse.forSucceeded(analysis, reasons);
+            }
+            case FAILED -> AnalysisResponse.forFailed(analysis);
+        };
+    }
+}

--- a/src/main/java/com/linclean/global/config/AsyncConfig.java
+++ b/src/main/java/com/linclean/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.linclean.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "analysisTaskExecutor")
+    public Executor analysisTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("analysis-async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/linclean/global/config/AsyncConfig.java
+++ b/src/main/java/com/linclean/global/config/AsyncConfig.java
@@ -6,6 +6,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @Configuration
 @EnableAsync
@@ -18,6 +19,7 @@ public class AsyncConfig {
         executor.setMaxPoolSize(10);
         executor.setQueueCapacity(100);
         executor.setThreadNamePrefix("analysis-async-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/linclean/global/config/SecurityConfig.java
+++ b/src/main/java/com/linclean/global/config/SecurityConfig.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linclean.auth.jwt.JwtAuthenticationEntryPoint;
 import com.linclean.auth.jwt.JwtAuthenticationFilter;
 import com.linclean.auth.jwt.JwtProvider;
+import com.linclean.global.security.InternalApiKeyFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,6 +25,9 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final ObjectMapper objectMapper;
 
+    @Value("${internal.api-key}")
+    private String internalApiKey;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -34,6 +39,7 @@ public class SecurityConfig {
                                 "/api/v1/auth/refresh"
                         ).permitAll()
                         .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/internal/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
@@ -42,6 +48,10 @@ public class SecurityConfig {
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtProvider, objectMapper),
                         UsernamePasswordAuthenticationFilter.class
+                )
+                .addFilterBefore(
+                        new InternalApiKeyFilter(internalApiKey, objectMapper),
+                        JwtAuthenticationFilter.class
                 );
 
         return http.build();

--- a/src/main/java/com/linclean/global/config/WebClientConfig.java
+++ b/src/main/java/com/linclean/global/config/WebClientConfig.java
@@ -17,6 +17,15 @@ public class WebClientConfig {
     @Value("${kakao.api-base-url}")
     private String kakaoApiBaseUrl;
 
+    @Value("${analysis-engine.base-url}")
+    private String analysisEngineBaseUrl;
+
+    @Value("${analysis-engine.connect-timeout-ms}")
+    private int analysisEngineConnectTimeoutMs;
+
+    @Value("${analysis-engine.read-timeout-s}")
+    private int analysisEngineReadTimeoutS;
+
     @Bean
     public WebClient kakaoWebClient() {
         HttpClient httpClient = HttpClient.create()
@@ -26,6 +35,19 @@ public class WebClientConfig {
 
         return WebClient.builder()
                 .baseUrl(kakaoApiBaseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
+    @Bean
+    public WebClient analysisEngineWebClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, analysisEngineConnectTimeoutMs)
+                .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(analysisEngineReadTimeoutS, TimeUnit.SECONDS)));
+
+        return WebClient.builder()
+                .baseUrl(analysisEngineBaseUrl)
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .build();
     }

--- a/src/main/java/com/linclean/global/exception/ErrorCode.java
+++ b/src/main/java/com/linclean/global/exception/ErrorCode.java
@@ -11,7 +11,12 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 토큰입니다."),
     REFRESH_TOKEN_REUSE_DETECTED(HttpStatus.UNAUTHORIZED, "AUTH_003", "Refresh Token 재사용이 감지되었습니다."),
     INVALID_KAKAO_TOKEN(HttpStatus.UNAUTHORIZED, "KAKAO_001", "유효하지 않은 카카오 토큰입니다."),
-    KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "KAKAO_002", "카카오 서버 오류가 발생했습니다.");
+    KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "KAKAO_002", "카카오 서버 오류가 발생했습니다."),
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "존재하지 않는 회원입니다."),
+
+    ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_001", "분석 결과를 찾을 수 없습니다."),
+    ANALYSIS_FORBIDDEN(HttpStatus.FORBIDDEN, "ANALYSIS_002", "본인의 분석 결과만 조회할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/linclean/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/linclean/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.linclean.global.exception;
 
 import com.linclean.auth.exception.InvalidTokenException;
 import com.linclean.auth.exception.KakaoAuthException;
+import com.linclean.domain.analysis.exception.AnalysisException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -17,6 +18,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<ErrorResponse> handleInvalidToken(InvalidTokenException e) {
         log.debug("토큰 오류: {}", e.getMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(ErrorResponse.of(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(AnalysisException.class)
+    public ResponseEntity<ErrorResponse> handleAnalysis(AnalysisException e) {
+        log.debug("분석 도메인 오류: {}", e.getMessage());
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(ErrorResponse.of(e.getErrorCode()));
     }

--- a/src/main/java/com/linclean/global/security/InternalApiKeyFilter.java
+++ b/src/main/java/com/linclean/global/security/InternalApiKeyFilter.java
@@ -1,0 +1,52 @@
+package com.linclean.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linclean.global.exception.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Instant;
+
+public class InternalApiKeyFilter extends OncePerRequestFilter {
+
+    private static final String HEADER_NAME = "X-Internal-Api-Key";
+
+    private final String expectedApiKey;
+    private final ObjectMapper objectMapper;
+
+    public InternalApiKeyFilter(String expectedApiKey, ObjectMapper objectMapper) {
+        this.expectedApiKey = expectedApiKey;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String key = request.getHeader(HEADER_NAME);
+
+        if (key == null || !key.equals(expectedApiKey)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            objectMapper.writeValue(response.getWriter(),
+                    new ErrorResponse("INTERNAL_UNAUTHORIZED", "유효하지 않은 내부 API 키입니다.", Instant.now()));
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !request.getRequestURI().startsWith("/internal/");
+    }
+}

--- a/src/main/java/com/linclean/global/security/InternalApiKeyFilter.java
+++ b/src/main/java/com/linclean/global/security/InternalApiKeyFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
 import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -15,6 +16,8 @@ import java.time.Instant;
 public class InternalApiKeyFilter extends OncePerRequestFilter {
 
     private static final String HEADER_NAME = "X-Internal-Api-Key";
+    private static final String REQUEST_ID_HEADER = "X-Request-ID";
+    private static final String MDC_REQUEST_ID_KEY = "requestId";
 
     private final String expectedApiKey;
     private final ObjectMapper objectMapper;
@@ -42,7 +45,15 @@ public class InternalApiKeyFilter extends OncePerRequestFilter {
             return;
         }
 
-        filterChain.doFilter(request, response);
+        String requestId = request.getHeader(REQUEST_ID_HEADER);
+        if (requestId != null) {
+            MDC.put(MDC_REQUEST_ID_KEY, requestId);
+        }
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_REQUEST_ID_KEY);
+        }
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,3 +41,11 @@ jwt:
 
 kakao:
   api-base-url: https://kapi.kakao.com
+
+analysis-engine:
+  base-url: ${ANALYSIS_ENGINE_URL}
+  connect-timeout-ms: ${ANALYSIS_ENGINE_CONNECT_TIMEOUT_MS:3000}
+  read-timeout-s: ${ANALYSIS_ENGINE_READ_TIMEOUT_S:5}
+
+internal:
+  api-key: ${INTERNAL_API_KEY}

--- a/src/main/resources/db/init.sql
+++ b/src/main/resources/db/init.sql
@@ -64,6 +64,7 @@ CREATE INDEX idx_notification_member_read ON notification (member_id, is_read);
 -- ============================================================
 CREATE TABLE analysis (
                           analysis_id     UUID            PRIMARY KEY,
+                          version         BIGINT          NOT NULL DEFAULT 0,
                           member_id       BIGINT          NOT NULL,
                           original_url    VARCHAR(2048)   NOT NULL,
                           final_url       VARCHAR(2048),


### PR DESCRIPTION
# 요약

URL 악성 분석 요청~결과 조회까지의 전체 플로우를 구현합니다.
클라이언트가 URL을 요청하면 Spring Boot가 DB에 저장 후 FastAPI 분석 엔진에 비동기로 위임하고, FastAPI가 분석 완료 시 콜백으로 결과를 전달합니다.
내부 API는 `X-Internal-Api-Key` 헤더로 인증하며, 낙관적 락과 requestId 검증으로 동시 콜백 및 오염된 콜백을 방어합니다.

## 1. 분석 요청/조회 API — AnalysisController, AnalysisService

47b6226 [Feat] Analysis 분석 요청/결과 조회 API 구현

- `POST /api/v1/analyses` — 분석 요청, 202 Accepted + analysisId 반환
- `GET /api/v1/analyses/{analysisId}` — 상태별 응답 (QUEUED / SUCCEEDED / FAILED)
- `TransactionSynchronizationManager.afterCommit()`으로 커밋 완료 후 비동기 엔진 호출 보장

## 2. Analysis 엔티티 상태 업데이트 + 낙관적 락

8fb93b8 [Feat] Analysis 엔티티 상태 업데이트 메서드 + 낙관적 락 추가

- `updateToSucceeded()`, `updateToFailed()` — 상태 전이 메서드 엔티티 내 캡슐화
- `@Version Long version` — 동시 콜백 레이스 컨디션 방어 (DB 레벨 낙관적 락)

## 3. FastAPI 콜백 통신 레이어

748ba85 [Feat] FastAPI 콜백 통신 레이어 구현

- `AnalysisAsyncRunner` — `@Async("analysisTaskExecutor")`로 FastAPI 위임, 호출 실패 시 FAILED 처리
- `AnalysisCallbackService` — QUEUED 상태 체크로 중복 콜백 멱등 처리
- `InternalApiKeyFilter` — `/internal/**` 경로 `X-Internal-Api-Key` 헤더 인증
- `AsyncConfig` — `ThreadPoolTaskExecutor` (core 2 / max 10 / queue 100), `CallerRunsPolicy`
- `WebClientConfig` — 분석 엔진 WebClient 빈 등록

## 4. 버그 수정 및 리팩토링

28356c8 [Fix] StagesDto Jackson 역직렬화 지원 (@Setter + @JsonProperty)
5de3b83 [Fix] 콜백 requestId 검증 및 스레드풀 포화 정책 추가

- requestId 불일치 콜백 조기 반환으로 오염된 콜백 방어

9e17a77 [Refactor] StagesDto → Stages 리네임 (Value Object 명칭 정정)

- jsonb 컬럼 매핑 Value Object에 Dto 접미사 제거, entity 패키지 유지
- dto 패키지로 이동 시 entity → dto 의존 방향 역전 문제 방지

17e376e [Fix] init.sql analysis 테이블 version 컬럼 누락 수정

- `@Version` 낙관적 락 컬럼 DDL 누락으로 INSERT 실패하던 버그 수정

## 5. 테스트

### 테스트 결과
~~~
=== Step 1: JWT 발급 ===
{"accessToken":"엑시스토큰 값","refreshToken":"리프레시 토큰 값","tokenType":"Bearer","expiresIn":1800,"isNewMember":false}
ACCESS_TOKEN: 엑세스 토큰 값

=== Step 2: 분석 요청 ===
{"analysisId":"7f000001-9de7-1604-819d-e7a92d2c0002","status":"queued"}
ANALYSIS_ID: 7f000001-9de7-1604-819d-e7a92d2c0002

=== Step 3: requestId 조회 및 콜백 테스트용 QUEUED 레코드 준비 ===
REQUEST_ID: 4d6c4d19-57f1-4c64-82cd-7c516a7e8cb7
UPDATE 1

=== Step 4: 콜백 시뮬레이션 (SUCCEEDED) ===
{"received":true}

=== Step 5: 결과 조회 ===
{"analysisId":"7f000001-9de7-1604-819d-e7a92d2c0002","status":"succeeded","originalUrl":"https://phishing-test.example.com","finalUrl":"https://phishing-test.example.com","verdict":"safe","score":90,"summary":"테스트 결과","reasons":[],"analyzedAt":"2026-05-02T00:00:00Z","elapsedMs":300}
~~~
### 디비 저장 확인
<img width="1435" height="116" alt="image" src="https://github.com/user-attachments/assets/3faad5af-c984-4291-bb11-9ca8c0d19f43" />

아이디 3번인 값을 보면 됩니다.

### 테스트에 사용한 스크립트
~~~
#!/bin/bash

BASE_URL="YOUR_BASE_URL"
INTERNAL_API_KEY="YOUR_INTERNAL_API_KEY"
PSQL="psql -h localhost -p 5432 -U linclean_user -d linclean"

# ── Step 1: JWT 발급 ──────────────────────────────────────────
KAKAO_TOKEN="YOUR_KAKAO_TOKEN"

echo "=== Step 1: JWT 발급 ==="
curl -s -X POST "$BASE_URL/api/v1/auth/kakao/login" \
  -H "Content-Type: application/json" \
  -d "{\"kakaoAccessToken\": \"$KAKAO_TOKEN\"}" | tee /tmp/auth.json
echo ""

ACCESS_TOKEN=$(cat /tmp/auth.json | grep -o '"accessToken":"[^"]*"' | cut -d'"' -f4)
echo "ACCESS_TOKEN: $ACCESS_TOKEN"
echo ""

# ── Step 2: 분석 요청 ──────────────────────────────────────────
echo "=== Step 2: 분석 요청 ==="
curl -s -X POST "$BASE_URL/api/v1/analyses" \
  -H "Authorization: Bearer $ACCESS_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"url": "https://phishing-test.example.com"}' | tee /tmp/analysis.json
echo ""

ANALYSIS_ID=$(cat /tmp/analysis.json | grep -o '"analysisId":"[^"]*"' | cut -d'"' -f4)
echo "ANALYSIS_ID: $ANALYSIS_ID"
echo ""

# ── Step 3: DB에서 requestId 자동 조회 후 QUEUED 레코드 재삽입 ──
echo "=== Step 3: requestId 조회 및 콜백 테스트용 QUEUED 레코드 준비 ==="

REQUEST_ID=$(PGPASSWORD="YOUR_PASSWORD" $PSQL -t -A -c "SELECT request_id FROM analysis WHERE analysis_id = '$ANALYSIS_ID';")
echo "REQUEST_ID: $REQUEST_ID"

# FastAPI 미실행으로 FAILED 상태가 됐을 경우 QUEUED로 되돌림
PGPASSWORD="RE@3ZR!" $PSQL -c "UPDATE analysis SET status = 'queued', version = 0, error_code = NULL, error_message = NULL WHERE analysis_id = '$ANALYSIS_ID';"
echo ""

# ── Step 4: 콜백 시뮬레이션 ──────────────────────────────────
echo "=== Step 4: 콜백 시뮬레이션 (SUCCEEDED) ==="
curl -s -X POST "$BASE_URL/internal/analysis-result" \
  -H "X-Internal-Api-Key: $INTERNAL_API_KEY" \
  -H "Content-Type: application/json" \
  -d "{\"analysisId\": \"$ANALYSIS_ID\", \"requestId\": \"$REQUEST_ID\", \"status\": \"succeeded\", \"originalUrl\": \"https://phishing-test.example.com\", \"finalUrl\": \"https://phishing-test.example.com\", \"verdict\": \"safe\", \"score\": 90, \"reasons\": [], \"summary\": \"테스트 결과\", \"engineVersion\": \"1.0.0\", \"analyzedAt\": \"2026-05-02T00:00:00Z\", \"elapsedMs\": 300}"
echo ""
echo ""

# ── Step 5: 결과 조회 ─────────────────────────────────────────
echo "=== Step 5: 결과 조회 ==="
curl -s -X GET "$BASE_URL/api/v1/analyses/$ANALYSIS_ID" \
  -H "Authorization: Bearer $ACCESS_TOKEN"
echo ""
~~~

# 연관 이슈 및 Close 할 이슈 작성

#12

close #12

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?