### PR TITLE
Clerk JWT 인증 검증 보완

### DIFF
--- a/src/main/java/com/linclean/security/ClerkAzpValidator.java
+++ b/src/main/java/com/linclean/security/ClerkAzpValidator.java
@@ -12,11 +12,17 @@ public class ClerkAzpValidator implements OAuth2TokenValidator<Jwt> {
     private final List<String> allowedParties;
 
     public ClerkAzpValidator(List<String> allowedParties) {
-        this.allowedParties = allowedParties;
+        this.allowedParties = allowedParties.stream()
+                .filter(allowedParty -> !allowedParty.isBlank())
+                .toList();
     }
 
     @Override
     public OAuth2TokenValidatorResult validate(Jwt jwt) {
+        if (allowedParties.isEmpty()) {
+            return OAuth2TokenValidatorResult.success();
+        }
+
         String azp = jwt.getClaimAsString("azp");
         if (azp == null || !allowedParties.contains(azp)) {
             return OAuth2TokenValidatorResult.failure(

--- a/src/main/java/com/linclean/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/linclean/security/JwtAuthenticationEntryPoint.java
@@ -6,6 +6,7 @@ import com.linclean.global.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -15,6 +16,7 @@ import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final ObjectMapper objectMapper;
@@ -25,6 +27,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
             HttpServletResponse response,
             AuthenticationException authException
     ) throws IOException {
+        log.warn("JWT authentication failed: {}", authException.getMessage());
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");


### PR DESCRIPTION
## 개요
Expo 모바일 앱에서 Clerk Google 로그인 후 `/api/v1/auth/me` 호출 시 401이 발생하는 문제를 확인했습니다.

확인 결과, Expo 앱에서 발급받은 Clerk 기본 세션 토큰에는 `azp` claim이 포함되지 않았습니다. 기존 백엔드 검증 로직은 `azp`가 없거나 허용 목록에 없으면 인증 실패로 처리하고 있어, Clerk에서 정상 발급된 모바일 세션 토큰도 401로 거절되는 상황이었습니다.

Clerk 문서상 `azp`는 토큰을 요청한 authorized party를 확인하기 위한 추가 검증 항목으로 권장되지만, 모바일/네이티브 환경의 기본 세션 토큰에서는 웹 origin 기반 `azp`가 포함되지 않을 수 있는 것으로 보입니다.

이에 따라 이번 PR에서는 `CLERK_ALLOWED_AZP` 설정값이 비어 있는 경우 `azp` 검증을 생략할 수 있는 방향을 제안합니다. 이 경우에도 Clerk JWKS 기반 서명 검증, 만료 시간(`exp`), 유효 시작 시간(`nbf`) 검증은 기존처럼 유지됩니다.

또한 추후 401 원인을 확인하기 쉽도록 JWT 인증 실패 시 Spring Security 인증 실패 메시지를 로그로 남기도록 했습니다.

## 주요 구현 내용
- `CLERK_ALLOWED_AZP` 설정값에서 빈 항목 제거
- 허용된 `azp` 목록이 비어 있는 경우 `azp` 검증 생략
- Expo 모바일 Clerk 기본 세션 토큰의 `azp` 부재 상황 대응 제안
- JWT 인증 실패 시 Spring Security 인증 실패 메시지 로그 출력

## 파일별 역할
- `src/main/java/com/linclean/security/ClerkAzpValidator.java`: `azp` 허용 목록이 비어 있을 때 검증을 생략하도록 처리
- `src/main/java/com/linclean/security/JwtAuthenticationEntryPoint.java`: JWT 인증 실패 원인 로그 추가

## 해결/검토 항목
- [x] Expo 모바일 Clerk 토큰에 `azp`가 없을 때 401이 발생하는 문제 확인
- [x] `CLERK_ALLOWED_AZP`를 비워 모바일 토큰을 허용할 수 있는 방식 제안
- [x] Clerk JWT 서명/만료/유효 시작 시간 검증은 유지
- [x] 인증 실패 원인 확인을 위한 로그 추가
- [ ] `azp` optional 처리 방식이 백엔드 보안 정책에 적합한지 검토 필요
- [ ] 장기적으로 모바일/API용 JWT Template과 `aud` 또는 custom claim 검증 방식 검토 필요

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 로컬에서 백엔드 서버 기동 확인
- [x] `/api/v1/auth/me`가 유효한 Clerk 모바일 토큰으로 200 응답하는 것 확인
- [ ] 백엔드 전체 테스트 확인 필요

## 참고
https://clerk.com/docs/guides/sessions/session-tokens#how-do-i-validate-a-session-token

프론트에서 확인한 Clerk 모바일 세션 토큰 claim에는 `iss`, `sub`, `sid`, `sts`, `exp`, `nbf`는 포함되어 있었지만 `azp`는 포함되어 있지 않았습니다.

```json
{
  "iss": "https://legible-finch-36.clerk.accounts.dev",
  "sub": "user_...",
  "sid": "sess_...",
  "sts": "active",
  "exp": 1778503419,
  "nbf": 1778503349
}
