### PR TITLE
[FEATURE] 회원 탈퇴 api 개발

### DIFF
--- a/src/main/java/com/linclean/domain/member/controller/MemberController.java
+++ b/src/main/java/com/linclean/domain/member/controller/MemberController.java
@@ -1,0 +1,24 @@
+package com.linclean.domain.member.controller;
+
+import com.linclean.domain.member.service.MemberWithdrawalService;
+import com.linclean.security.MemberPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController implements MemberControllerDocs {
+
+    private final MemberWithdrawalService memberWithdrawalService;
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal MemberPrincipal principal) {
+        memberWithdrawalService.withdraw(principal.memberId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/linclean/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/com/linclean/domain/member/controller/MemberControllerDocs.java
@@ -1,0 +1,25 @@
+package com.linclean.domain.member.controller;
+
+import com.linclean.global.exception.ErrorResponse;
+import com.linclean.security.MemberPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "Member", description = "회원 API")
+public interface MemberControllerDocs {
+
+    @Operation(summary = "회원 탈퇴", description = "현재 인증된 사용자의 계정을 탈퇴합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "탈퇴 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 회원",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> withdraw(@AuthenticationPrincipal MemberPrincipal principal);
+}

--- a/src/main/java/com/linclean/domain/member/exception/MemberException.java
+++ b/src/main/java/com/linclean/domain/member/exception/MemberException.java
@@ -1,0 +1,15 @@
+package com.linclean.domain.member.exception;
+
+import com.linclean.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class MemberException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public MemberException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/linclean/domain/member/exception/WithdrawnMemberException.java
+++ b/src/main/java/com/linclean/domain/member/exception/WithdrawnMemberException.java
@@ -1,0 +1,7 @@
+package com.linclean.domain.member.exception;
+
+public class WithdrawnMemberException extends RuntimeException {
+    public WithdrawnMemberException() {
+        super("탈퇴한 회원입니다.");
+    }
+}

--- a/src/main/java/com/linclean/domain/member/infrastructure/ClerkManagementClient.java
+++ b/src/main/java/com/linclean/domain/member/infrastructure/ClerkManagementClient.java
@@ -1,0 +1,34 @@
+package com.linclean.domain.member.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClerkManagementClient {
+
+    private final WebClient clerkManagementWebClient;
+
+    public void deleteUser(String clerkId) {
+        try {
+            clerkManagementWebClient.delete()
+                    .uri("/v1/users/{clerkId}", clerkId)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block();
+            log.info("Clerk 계정 삭제 완료 - clerkId={}", clerkId);
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().value() == 404) {
+                log.warn("Clerk 계정이 이미 삭제됨 - clerkId={}", clerkId);
+                return;
+            }
+            log.error("Clerk 계정 삭제 실패 - clerkId={}, status={}", clerkId, e.getStatusCode(), e);
+        } catch (Exception e) {
+            log.error("Clerk API 연결 오류 - clerkId={}", clerkId, e);
+        }
+    }
+}

--- a/src/main/java/com/linclean/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/linclean/domain/member/repository/MemberRepository.java
@@ -12,6 +12,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // @SQLRestriction("deleted_at IS NULL") 덕분에 자동으로 활성 회원만 조회됨
     Optional<Member> findByClerkId(String clerkId);
 
+    // @SQLRestriction 우회: 탈퇴(soft-deleted) 회원 존재 여부 확인
+    @Query(value = "SELECT COUNT(*) > 0 FROM member WHERE clerk_id = :clerkId AND deleted_at IS NOT NULL", nativeQuery = true)
+    boolean existsWithdrawnByClerkId(@Param("clerkId") String clerkId);
+
     // native query로 @SQLRestriction, @SQLDelete 모두 우회하여 물리 삭제
     @Modifying
     @Query(

--- a/src/main/java/com/linclean/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/linclean/domain/member/repository/MemberRepository.java
@@ -2,10 +2,21 @@ package com.linclean.domain.member.repository;
 
 import com.linclean.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     // @SQLRestriction("deleted_at IS NULL") 덕분에 자동으로 활성 회원만 조회됨
     Optional<Member> findByClerkId(String clerkId);
+
+    // native query로 @SQLRestriction, @SQLDelete 모두 우회하여 물리 삭제
+    @Modifying
+    @Query(
+            value = "DELETE FROM member WHERE deleted_at IS NOT NULL AND deleted_at < now() - CAST(:retentionDays || ' days' AS INTERVAL)",
+            nativeQuery = true
+    )
+    int hardDeleteExpiredMembers(@Param("retentionDays") int retentionDays);
 }

--- a/src/main/java/com/linclean/domain/member/service/MemberHardDeleteScheduler.java
+++ b/src/main/java/com/linclean/domain/member/service/MemberHardDeleteScheduler.java
@@ -1,0 +1,32 @@
+package com.linclean.domain.member.service;
+
+import com.linclean.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberHardDeleteScheduler {
+
+    private final MemberRepository memberRepository;
+
+    @Value("${member.withdrawal.retention-days}")
+    private int retentionDays;
+
+    @Scheduled(cron = "${member.withdrawal.hard-delete-cron:0 0 3 * * *}")
+    @Transactional
+    public void hardDeleteExpiredMembers() {
+        log.info("하드 삭제 스케줄러 시작 - retentionDays={}", retentionDays);
+        try {
+            int deleted = memberRepository.hardDeleteExpiredMembers(retentionDays);
+            log.info("하드 삭제 완료 - deletedCount={}", deleted);
+        } catch (Exception e) {
+            log.error("하드 삭제 스케줄러 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/linclean/domain/member/service/MemberWithdrawalService.java
+++ b/src/main/java/com/linclean/domain/member/service/MemberWithdrawalService.java
@@ -1,0 +1,39 @@
+package com.linclean.domain.member.service;
+
+import com.linclean.domain.member.entity.Member;
+import com.linclean.domain.member.exception.MemberException;
+import com.linclean.domain.member.infrastructure.ClerkManagementClient;
+import com.linclean.domain.member.repository.MemberRepository;
+import com.linclean.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberWithdrawalService {
+
+    private final MemberRepository memberRepository;
+    private final ClerkManagementClient clerkManagementClient;
+
+    @Transactional
+    public void withdraw(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+        String clerkId = member.getClerkId();
+        memberRepository.delete(member);
+        log.info("회원 소프트 삭제 완료 - memberId={}", memberId);
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                clerkManagementClient.deleteUser(clerkId);
+            }
+        });
+    }
+}

--- a/src/main/java/com/linclean/global/config/ClerkManagementWebClientConfig.java
+++ b/src/main/java/com/linclean/global/config/ClerkManagementWebClientConfig.java
@@ -1,0 +1,37 @@
+package com.linclean.global.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class ClerkManagementWebClientConfig {
+
+    @Value("${clerk.secret-key}")
+    private String clerkSecretKey;
+
+    @Value("${clerk.management-api-base-url}")
+    private String clerkManagementApiBaseUrl;
+
+    @Bean
+    public WebClient clerkManagementWebClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(10, TimeUnit.SECONDS)));
+
+        return WebClient.builder()
+                .baseUrl(clerkManagementApiBaseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + clerkSecretKey)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/src/main/java/com/linclean/global/config/SchedulingConfig.java
+++ b/src/main/java/com/linclean/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.linclean.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/linclean/global/exception/ErrorCode.java
+++ b/src/main/java/com/linclean/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     REFRESH_TOKEN_REUSE_DETECTED(HttpStatus.UNAUTHORIZED, "AUTH_003", "Refresh Token 재사용이 감지되었습니다."),
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "존재하지 않는 회원입니다."),
+    MEMBER_WITHDRAWAL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER_002", "회원 탈퇴 처리 중 오류가 발생했습니다."),
 
     ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_001", "분석 결과를 찾을 수 없습니다."),
     ANALYSIS_FORBIDDEN(HttpStatus.FORBIDDEN, "ANALYSIS_002", "본인의 분석 결과만 조회할 수 있습니다."),

--- a/src/main/java/com/linclean/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/linclean/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.linclean.global.exception;
 
 import com.linclean.domain.analysis.exception.AnalysisException;
 import com.linclean.domain.link.exception.SavedLinkException;
+import com.linclean.domain.member.exception.MemberException;
 import com.linclean.domain.terms.exception.TermsException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,13 @@ import java.time.Instant;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<ErrorResponse> handleMember(MemberException e) {
+        log.debug("회원 도메인 오류: {}", e.getMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(ErrorResponse.of(e.getErrorCode()));
+    }
 
     @ExceptionHandler(AnalysisException.class)
     public ResponseEntity<ErrorResponse> handleAnalysis(AnalysisException e) {

--- a/src/main/java/com/linclean/security/ClerkJwtAuthenticationConverter.java
+++ b/src/main/java/com/linclean/security/ClerkJwtAuthenticationConverter.java
@@ -1,8 +1,10 @@
 package com.linclean.security;
 
 import com.linclean.domain.member.entity.Member;
+import com.linclean.domain.member.exception.WithdrawnMemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -18,7 +20,12 @@ public class ClerkJwtAuthenticationConverter implements Converter<Jwt, UsernameP
 
     @Override
     public UsernamePasswordAuthenticationToken convert(Jwt jwt) {
-        Member member = memberSyncService.findOrCreate(jwt.getSubject());
+        Member member;
+        try {
+            member = memberSyncService.findOrCreate(jwt.getSubject());
+        } catch (WithdrawnMemberException e) {
+            throw new BadCredentialsException(e.getMessage());
+        }
         MemberPrincipal principal = new MemberPrincipal(member.getId(), member.getPublicId());
         return new UsernamePasswordAuthenticationToken(
                 principal, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))

--- a/src/main/java/com/linclean/security/MemberSyncService.java
+++ b/src/main/java/com/linclean/security/MemberSyncService.java
@@ -1,6 +1,7 @@
 package com.linclean.security;
 
 import com.linclean.domain.member.entity.Member;
+import com.linclean.domain.member.exception.WithdrawnMemberException;
 import com.linclean.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -15,6 +16,9 @@ public class MemberSyncService {
 
     @Transactional
     public Member findOrCreate(String clerkId) {
+        if (memberRepository.existsWithdrawnByClerkId(clerkId)) {
+            throw new WithdrawnMemberException();
+        }
         try {
             return memberRepository.findByClerkId(clerkId)
                     .orElseGet(() -> memberRepository.save(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,8 @@ spring:
 
 clerk:
   issuer: ${CLERK_ISSUER}
+  secret-key: ${CLERK_SECRET_KEY}
+  management-api-base-url: https://api.clerk.com
 
 server:
   port: ${API_PORT}
@@ -49,6 +51,11 @@ analysis-engine:
 
 internal:
   api-key: ${INTERNAL_API_KEY}
+
+member:
+  withdrawal:
+    retention-days: ${MEMBER_WITHDRAWAL_RETENTION_DAYS:30}
+    hard-delete-cron: ${MEMBER_WITHDRAWAL_HARD_DELETE_CRON:0 0 3 * * *}
 
 springdoc:
   swagger-ui:

--- a/src/test/java/com/linclean/domain/member/service/MemberHardDeleteSchedulerTest.java
+++ b/src/test/java/com/linclean/domain/member/service/MemberHardDeleteSchedulerTest.java
@@ -1,0 +1,103 @@
+package com.linclean.domain.member.service;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+class MemberHardDeleteSchedulerTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17")
+            .withDatabaseName("linclean_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @Autowired
+    MemberHardDeleteScheduler scheduler;
+
+    @Autowired
+    EntityManager em;
+
+    @Nested
+    class hardDeleteExpiredMembers {
+
+        @Test
+        @Transactional
+        void 보존기간을_초과한_탈퇴회원은_물리삭제된다() {
+            em.createNativeQuery("""
+                    INSERT INTO member (public_id, clerk_id, created_at, updated_at, deleted_at)
+                    VALUES (gen_random_uuid(), 'expired-clerk-id', now(), now(), now() - INTERVAL '31 days')
+                    """).executeUpdate();
+            em.flush();
+
+            scheduler.hardDeleteExpiredMembers();
+
+            Long count = count("expired-clerk-id");
+            assertThat(count).isZero();
+        }
+
+        @Test
+        @Transactional
+        void 보존기간_이내의_탈퇴회원은_삭제되지_않는다() {
+            em.createNativeQuery("""
+                    INSERT INTO member (public_id, clerk_id, created_at, updated_at, deleted_at)
+                    VALUES (gen_random_uuid(), 'recent-clerk-id', now(), now(), now() - INTERVAL '10 days')
+                    """).executeUpdate();
+            em.flush();
+
+            scheduler.hardDeleteExpiredMembers();
+
+            Long count = count("recent-clerk-id");
+            assertThat(count).isOne();
+        }
+
+        @Test
+        @Transactional
+        void 활성_회원은_삭제되지_않는다() {
+            em.createNativeQuery("""
+                    INSERT INTO member (public_id, clerk_id, created_at, updated_at, deleted_at)
+                    VALUES (gen_random_uuid(), 'active-clerk-id', now(), now(), NULL)
+                    """).executeUpdate();
+            em.flush();
+
+            scheduler.hardDeleteExpiredMembers();
+
+            Long count = count("active-clerk-id");
+            assertThat(count).isOne();
+        }
+
+        private Long count(String clerkId) {
+            return ((Number) em.createNativeQuery(
+                    "SELECT COUNT(*) FROM member WHERE clerk_id = '" + clerkId + "'"
+            ).getSingleResult()).longValue();
+        }
+    }
+}

--- a/src/test/java/com/linclean/domain/member/service/MemberHardDeleteSchedulerTest.java
+++ b/src/test/java/com/linclean/domain/member/service/MemberHardDeleteSchedulerTest.java
@@ -81,6 +81,21 @@ class MemberHardDeleteSchedulerTest {
 
         @Test
         @Transactional
+        void 정확히_보존기간_당일인_탈퇴회원은_삭제되지_않는다() {
+            em.createNativeQuery("""
+                    INSERT INTO member (public_id, clerk_id, created_at, updated_at, deleted_at)
+                    VALUES (gen_random_uuid(), 'boundary-clerk-id', now(), now(), now() - INTERVAL '30 days')
+                    """).executeUpdate();
+            em.flush();
+
+            scheduler.hardDeleteExpiredMembers();
+
+            Long count = count("boundary-clerk-id");
+            assertThat(count).isOne();
+        }
+
+        @Test
+        @Transactional
         void 활성_회원은_삭제되지_않는다() {
             em.createNativeQuery("""
                     INSERT INTO member (public_id, clerk_id, created_at, updated_at, deleted_at)

--- a/src/test/java/com/linclean/domain/member/service/MemberSyncServiceTest.java
+++ b/src/test/java/com/linclean/domain/member/service/MemberSyncServiceTest.java
@@ -11,6 +11,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.dao.DataIntegrityViolationException;
+
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,6 +68,20 @@ class MemberSyncServiceTest {
 
             assertThat(result.getClerkId()).isEqualTo("new-clerk-id");
             verify(memberRepository).save(any());
+        }
+
+        @Test
+        void 동시_생성_충돌시_DataIntegrityViolationException을_잡고_재조회한_회원을_반환한다() {
+            Member savedMember = Member.builder().clerkId("race-clerk-id").build();
+            given(memberRepository.existsWithdrawnByClerkId("race-clerk-id")).willReturn(false);
+            given(memberRepository.findByClerkId("race-clerk-id"))
+                    .willReturn(Optional.empty())             // 1차 조회: 없음
+                    .willReturn(Optional.of(savedMember));   // 예외 후 재조회: 있음
+            given(memberRepository.save(any())).willThrow(new DataIntegrityViolationException("duplicate"));
+
+            Member result = memberSyncService.findOrCreate("race-clerk-id");
+
+            assertThat(result.getClerkId()).isEqualTo("race-clerk-id");
         }
     }
 }

--- a/src/test/java/com/linclean/domain/member/service/MemberSyncServiceTest.java
+++ b/src/test/java/com/linclean/domain/member/service/MemberSyncServiceTest.java
@@ -1,0 +1,71 @@
+package com.linclean.domain.member.service;
+
+import com.linclean.domain.member.entity.Member;
+import com.linclean.domain.member.exception.WithdrawnMemberException;
+import com.linclean.domain.member.repository.MemberRepository;
+import com.linclean.security.MemberSyncService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MemberSyncServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @InjectMocks
+    MemberSyncService memberSyncService;
+
+    @Nested
+    class findOrCreate {
+
+        @Test
+        void 탈퇴한_clerkId로_인증시_WithdrawnMemberException이_발생한다() {
+            given(memberRepository.existsWithdrawnByClerkId("withdrawn-clerk-id")).willReturn(true);
+
+            assertThatThrownBy(() -> memberSyncService.findOrCreate("withdrawn-clerk-id"))
+                    .isInstanceOf(WithdrawnMemberException.class);
+
+            verify(memberRepository, never()).findByClerkId(any());
+            verify(memberRepository, never()).save(any());
+        }
+
+        @Test
+        void 기존_회원은_탈퇴_여부_확인_후_그대로_반환한다() {
+            Member member = Member.builder().clerkId("existing-clerk-id").build();
+            given(memberRepository.existsWithdrawnByClerkId("existing-clerk-id")).willReturn(false);
+            given(memberRepository.findByClerkId("existing-clerk-id")).willReturn(Optional.of(member));
+
+            Member result = memberSyncService.findOrCreate("existing-clerk-id");
+
+            assertThat(result.getClerkId()).isEqualTo("existing-clerk-id");
+            verify(memberRepository, never()).save(any());
+        }
+
+        @Test
+        void 신규_clerkId는_탈퇴_여부_확인_후_새_회원을_생성한다() {
+            Member newMember = Member.builder().clerkId("new-clerk-id").build();
+            given(memberRepository.existsWithdrawnByClerkId("new-clerk-id")).willReturn(false);
+            given(memberRepository.findByClerkId("new-clerk-id")).willReturn(Optional.empty());
+            given(memberRepository.save(any())).willReturn(newMember);
+
+            Member result = memberSyncService.findOrCreate("new-clerk-id");
+
+            assertThat(result.getClerkId()).isEqualTo("new-clerk-id");
+            verify(memberRepository).save(any());
+        }
+    }
+}

--- a/src/test/java/com/linclean/domain/member/service/MemberWithdrawalServiceTest.java
+++ b/src/test/java/com/linclean/domain/member/service/MemberWithdrawalServiceTest.java
@@ -67,5 +67,19 @@ class MemberWithdrawalServiceTest {
 
             verify(memberRepository).delete(member);
         }
+
+        @Test
+        void 정상_탈퇴시_커밋_후_Clerk_계정_삭제가_호출된다() {
+            Member member = Member.builder().clerkId("test-clerk-id").build();
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+            memberWithdrawalService.withdraw(1L);
+
+            // afterCommit 콜백 수동 트리거 — 실제 트랜잭션 커밋 시점을 재현
+            TransactionSynchronizationManager.getSynchronizations()
+                    .forEach(sync -> sync.afterCommit());
+
+            verify(clerkManagementClient).deleteUser("test-clerk-id");
+        }
     }
 }

--- a/src/test/java/com/linclean/domain/member/service/MemberWithdrawalServiceTest.java
+++ b/src/test/java/com/linclean/domain/member/service/MemberWithdrawalServiceTest.java
@@ -1,0 +1,71 @@
+package com.linclean.domain.member.service;
+
+import com.linclean.domain.member.entity.Member;
+import com.linclean.domain.member.exception.MemberException;
+import com.linclean.domain.member.infrastructure.ClerkManagementClient;
+import com.linclean.domain.member.repository.MemberRepository;
+import com.linclean.global.exception.ErrorCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MemberWithdrawalServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    ClerkManagementClient clerkManagementClient;
+
+    @InjectMocks
+    MemberWithdrawalService memberWithdrawalService;
+
+    @BeforeEach
+    void setUp() {
+        // withdraw() 내부의 TransactionSynchronizationManager.registerSynchronization() 호출을 위해 필요
+        TransactionSynchronizationManager.initSynchronization();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TransactionSynchronizationManager.clearSynchronization();
+    }
+
+    @Nested
+    class withdraw {
+
+        @Test
+        void 존재하지_않는_회원_탈퇴시_MEMBER_NOT_FOUND_예외가_발생한다() {
+            given(memberRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> memberWithdrawalService.withdraw(999L))
+                    .isInstanceOf(MemberException.class)
+                    .satisfies(e -> assertThat(((MemberException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.MEMBER_NOT_FOUND));
+        }
+
+        @Test
+        void 정상_탈퇴시_회원_소프트삭제가_호출된다() {
+            Member member = Member.builder().clerkId("test-clerk-id").build();
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+            memberWithdrawalService.withdraw(1L);
+
+            verify(memberRepository).delete(member);
+        }
+    }
+}


### PR DESCRIPTION
# 요약

소프트 삭제 + 스케줄러 하드 삭제 방식으로 회원 탈퇴 API를 구현합니다.

- `DELETE /api/v1/members/me` 엔드포인트 추가
- 탈퇴 시 로컬 DB soft delete 후 Clerk 계정 삭제 연동
- 탈퇴한 clerkId로 기존 JWT 재인증 시 신규 계정 생성 차단 (401 반환)
- 매일 새벽 3시 스케줄러로 retention 기간(기본 30일) 초과 탈퇴 회원 물리 삭제

### 탈퇴 흐름

```
DELETE /api/v1/members/me
  → soft delete (deleted_at 설정)
  → 트랜잭션 커밋
  → afterCommit: Clerk DELETE /v1/users/{clerkId}
  → 204 반환
```

### 재인증 차단 흐름

```
탈퇴 후 기존 JWT로 요청
  → MemberSyncService.findOrCreate()
  → existsWithdrawnByClerkId() native query로 탈퇴 여부 확인
  → WithdrawnMemberException → BadCredentialsException → 401
```

### 테스트

- `MemberSyncServiceTest`: 탈퇴 회원 재인증 차단, 기존/신규 회원 흐름, 동시 생성 충돌 복구
- `MemberWithdrawalServiceTest`: MEMBER_NOT_FOUND 예외, 소프트 삭제 및 afterCommit Clerk 삭제 호출 검증
- `MemberHardDeleteSchedulerTest`: 보존기간 초과/경계/이내/활성 회원 하드 삭제 경계값 검증 (TestContainers)

<img width="462" height="561" alt="image" src="https://github.com/user-attachments/assets/fdd96433-bb32-4406-acdb-934b36acd85f" />
전체 테스트 통과

# 연관 이슈 및 Close 할 이슈 작성

close #33

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?