### PR TITLE
[FEATURE] 링크 이름 수정 api 개발

### DIFF
--- a/src/main/java/com/linclean/domain/link/controller/SavedLinkController.java
+++ b/src/main/java/com/linclean/domain/link/controller/SavedLinkController.java
@@ -3,10 +3,12 @@ package com.linclean.domain.link.controller;
 import com.linclean.domain.link.dto.request.CategoryUpdateRequest;
 import com.linclean.domain.link.dto.request.SavedLinkCreateRequest;
 import com.linclean.domain.link.dto.request.SavedLinkListQuery;
+import com.linclean.domain.link.dto.request.SavedLinkTitleUpdateRequest;
 import com.linclean.domain.link.dto.response.BookmarkToggleResponse;
 import com.linclean.domain.link.dto.response.CategoryUpdateResponse;
 import com.linclean.domain.link.dto.response.SavedLinkListResponse;
 import com.linclean.domain.link.dto.response.SavedLinkResponse;
+import com.linclean.domain.link.dto.response.SavedLinkTitleUpdateResponse;
 import com.linclean.domain.link.service.SavedLinkService;
 import com.linclean.global.web.ApiResponse;
 import com.linclean.security.MemberPrincipal;
@@ -69,5 +71,13 @@ public class SavedLinkController implements SavedLinkControllerDocs {
             @PathVariable Long id,
             @RequestBody CategoryUpdateRequest request) {
         return ResponseEntity.ok(ApiResponse.of(savedLinkService.updateCategory(principal.memberId(), id, request)));
+    }
+
+    @PatchMapping("/{id}/title")
+    public ResponseEntity<ApiResponse<SavedLinkTitleUpdateResponse>> updateTitle(
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @PathVariable Long id,
+            @Valid @RequestBody SavedLinkTitleUpdateRequest request) {
+        return ResponseEntity.ok(ApiResponse.of(savedLinkService.updateTitle(principal.memberId(), id, request)));
     }
 }

--- a/src/main/java/com/linclean/domain/link/controller/SavedLinkControllerDocs.java
+++ b/src/main/java/com/linclean/domain/link/controller/SavedLinkControllerDocs.java
@@ -3,10 +3,12 @@ package com.linclean.domain.link.controller;
 import com.linclean.domain.link.dto.request.CategoryUpdateRequest;
 import com.linclean.domain.link.dto.request.SavedLinkCreateRequest;
 import com.linclean.domain.link.dto.request.SavedLinkListQuery;
+import com.linclean.domain.link.dto.request.SavedLinkTitleUpdateRequest;
 import com.linclean.domain.link.dto.response.BookmarkToggleResponse;
 import com.linclean.domain.link.dto.response.CategoryUpdateResponse;
 import com.linclean.domain.link.dto.response.SavedLinkListResponse;
 import com.linclean.domain.link.dto.response.SavedLinkResponse;
+import com.linclean.domain.link.dto.response.SavedLinkTitleUpdateResponse;
 import com.linclean.global.exception.ErrorResponse;
 import com.linclean.global.web.ApiResponse;
 import com.linclean.security.MemberPrincipal;
@@ -86,5 +88,19 @@ public interface SavedLinkControllerDocs {
             @AuthenticationPrincipal MemberPrincipal principal,
             @Parameter(description = "저장 링크 ID") @PathVariable Long id,
             @RequestBody CategoryUpdateRequest request
+    );
+
+    @Operation(summary = "제목 변경", description = "저장 링크의 제목을 변경합니다. 동일 회원 내 중복된 제목은 허용하지 않습니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "저장 링크 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "중복된 제목",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ApiResponse<SavedLinkTitleUpdateResponse>> updateTitle(
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @Parameter(description = "저장 링크 ID") @PathVariable Long id,
+            @Valid @RequestBody SavedLinkTitleUpdateRequest request
     );
 }

--- a/src/main/java/com/linclean/domain/link/controller/SavedLinkControllerDocs.java
+++ b/src/main/java/com/linclean/domain/link/controller/SavedLinkControllerDocs.java
@@ -93,6 +93,8 @@ public interface SavedLinkControllerDocs {
     @Operation(summary = "제목 변경", description = "저장 링크의 제목을 변경합니다. 동일 회원 내 중복된 제목은 허용하지 않습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 요청 (빈 제목, 500자 초과)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "저장 링크 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "중복된 제목",

--- a/src/main/java/com/linclean/domain/link/dto/request/SavedLinkTitleUpdateRequest.java
+++ b/src/main/java/com/linclean/domain/link/dto/request/SavedLinkTitleUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.linclean.domain.link.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SavedLinkTitleUpdateRequest(
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 500, message = "제목은 500자 이하여야 합니다.")
+        String title
+) {}

--- a/src/main/java/com/linclean/domain/link/dto/response/SavedLinkTitleUpdateResponse.java
+++ b/src/main/java/com/linclean/domain/link/dto/response/SavedLinkTitleUpdateResponse.java
@@ -1,0 +1,3 @@
+package com.linclean.domain.link.dto.response;
+
+public record SavedLinkTitleUpdateResponse(Long id, String title) {}

--- a/src/main/java/com/linclean/domain/link/entity/SavedLink.java
+++ b/src/main/java/com/linclean/domain/link/entity/SavedLink.java
@@ -55,4 +55,8 @@ public class SavedLink extends BaseEntity {
     public void updateCategory(Category category) {
         this.category = category;
     }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
 }

--- a/src/main/java/com/linclean/domain/link/repository/SavedLinkRepository.java
+++ b/src/main/java/com/linclean/domain/link/repository/SavedLinkRepository.java
@@ -17,6 +17,8 @@ public interface SavedLinkRepository extends JpaRepository<SavedLink, Long> {
 
     boolean existsByMember_IdAndTitle(Long memberId, String title);
 
+    boolean existsByMember_IdAndTitleAndIdNot(Long memberId, String title, Long id);
+
     @Query("""
             SELECT sl FROM SavedLink sl
             JOIN FETCH sl.analysis

--- a/src/main/java/com/linclean/domain/link/service/SavedLinkService.java
+++ b/src/main/java/com/linclean/domain/link/service/SavedLinkService.java
@@ -143,6 +143,15 @@ public class SavedLinkService {
         }
 
         link.updateTitle(request.title());
+        try {
+            savedLinkRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            String msg = e.getMessage() != null ? e.getMessage() : "";
+            if (msg.contains("uq_saved_link_member_title")) {
+                throw new SavedLinkException(ErrorCode.SAVED_LINK_TITLE_DUPLICATE);
+            }
+            throw e;
+        }
         return new SavedLinkTitleUpdateResponse(link.getId(), link.getTitle());
     }
 

--- a/src/main/java/com/linclean/domain/link/service/SavedLinkService.java
+++ b/src/main/java/com/linclean/domain/link/service/SavedLinkService.java
@@ -8,10 +8,12 @@ import com.linclean.domain.analysis.repository.AnalysisRepository;
 import com.linclean.domain.link.dto.request.CategoryUpdateRequest;
 import com.linclean.domain.link.dto.request.SavedLinkCreateRequest;
 import com.linclean.domain.link.dto.request.SavedLinkListQuery;
+import com.linclean.domain.link.dto.request.SavedLinkTitleUpdateRequest;
 import com.linclean.domain.link.dto.response.BookmarkToggleResponse;
 import com.linclean.domain.link.dto.response.CategoryUpdateResponse;
 import com.linclean.domain.link.dto.response.SavedLinkListResponse;
 import com.linclean.domain.link.dto.response.SavedLinkResponse;
+import com.linclean.domain.link.dto.response.SavedLinkTitleUpdateResponse;
 import com.linclean.domain.link.entity.Category;
 import com.linclean.domain.link.entity.SavedLink;
 import com.linclean.domain.link.exception.SavedLinkException;
@@ -129,6 +131,19 @@ public class SavedLinkService {
         link.updateCategory(category);
         Long resultCategoryId = link.getCategory() != null ? link.getCategory().getId() : null;
         return new CategoryUpdateResponse(link.getId(), resultCategoryId);
+    }
+
+    @Transactional
+    public SavedLinkTitleUpdateResponse updateTitle(Long memberId, Long id, SavedLinkTitleUpdateRequest request) {
+        SavedLink link = savedLinkRepository.findByIdAndMember_Id(id, memberId)
+                .orElseThrow(() -> new SavedLinkException(ErrorCode.SAVED_LINK_NOT_FOUND));
+
+        if (savedLinkRepository.existsByMember_IdAndTitleAndIdNot(memberId, request.title(), id)) {
+            throw new SavedLinkException(ErrorCode.SAVED_LINK_TITLE_DUPLICATE);
+        }
+
+        link.updateTitle(request.title());
+        return new SavedLinkTitleUpdateResponse(link.getId(), link.getTitle());
     }
 
     private Long decodeCursor(String cursor) {

--- a/src/test/java/com/linclean/domain/link/controller/SavedLinkControllerTest.java
+++ b/src/test/java/com/linclean/domain/link/controller/SavedLinkControllerTest.java
@@ -8,6 +8,7 @@ import com.linclean.domain.link.dto.response.BookmarkToggleResponse;
 import com.linclean.domain.link.dto.response.CategoryUpdateResponse;
 import com.linclean.domain.link.dto.response.SavedLinkListResponse;
 import com.linclean.domain.link.dto.response.SavedLinkResponse;
+import com.linclean.domain.link.dto.response.SavedLinkTitleUpdateResponse;
 import com.linclean.domain.link.exception.SavedLinkException;
 import com.linclean.domain.link.service.SavedLinkService;
 import com.linclean.global.exception.ErrorCode;
@@ -391,5 +392,67 @@ class SavedLinkControllerTest {
                         .content("{\"categoryId\": 99}"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(ErrorCode.CATEGORY_NOT_FOUND.getCode()));
+    }
+
+    // ── PATCH /api/v1/saved-links/{id}/title ─────────────────────────────
+
+    @Test
+    void updateTitle_returns200() throws Exception {
+        given(savedLinkService.updateTitle(eq(1L), eq(10L), any()))
+                .willReturn(new SavedLinkTitleUpdateResponse(10L, "새 제목"));
+
+        mockMvc.perform(patch("/api/v1/saved-links/10/title")
+                        .with(authentication(AUTH))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"새 제목\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(10))
+                .andExpect(jsonPath("$.data.title").value("새 제목"));
+    }
+
+    @Test
+    void updateTitle_blankTitle_returns400() throws Exception {
+        mockMvc.perform(patch("/api/v1/saved-links/10/title")
+                        .with(authentication(AUTH))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void updateTitle_titleTooLong_returns400() throws Exception {
+        mockMvc.perform(patch("/api/v1/saved-links/10/title")
+                        .with(authentication(AUTH))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("title", "a".repeat(501)))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void updateTitle_notFound_returns404() throws Exception {
+        given(savedLinkService.updateTitle(eq(1L), eq(99L), any()))
+                .willThrow(new SavedLinkException(ErrorCode.SAVED_LINK_NOT_FOUND));
+
+        mockMvc.perform(patch("/api/v1/saved-links/99/title")
+                        .with(authentication(AUTH))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"새 제목\"}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.SAVED_LINK_NOT_FOUND.getCode()));
+    }
+
+    @Test
+    void updateTitle_titleDuplicate_returns409() throws Exception {
+        given(savedLinkService.updateTitle(eq(1L), eq(10L), any()))
+                .willThrow(new SavedLinkException(ErrorCode.SAVED_LINK_TITLE_DUPLICATE));
+
+        mockMvc.perform(patch("/api/v1/saved-links/10/title")
+                        .with(authentication(AUTH))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"중복 제목\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value(ErrorCode.SAVED_LINK_TITLE_DUPLICATE.getCode()));
     }
 }

--- a/src/test/java/com/linclean/domain/link/service/SavedLinkServiceTest.java
+++ b/src/test/java/com/linclean/domain/link/service/SavedLinkServiceTest.java
@@ -7,10 +7,12 @@ import com.linclean.domain.analysis.repository.AnalysisRepository;
 import com.linclean.domain.link.dto.request.CategoryUpdateRequest;
 import com.linclean.domain.link.dto.request.SavedLinkCreateRequest;
 import com.linclean.domain.link.dto.request.SavedLinkListQuery;
+import com.linclean.domain.link.dto.request.SavedLinkTitleUpdateRequest;
 import com.linclean.domain.link.dto.response.BookmarkToggleResponse;
 import com.linclean.domain.link.dto.response.CategoryUpdateResponse;
 import com.linclean.domain.link.dto.response.SavedLinkListResponse;
 import com.linclean.domain.link.dto.response.SavedLinkResponse;
+import com.linclean.domain.link.dto.response.SavedLinkTitleUpdateResponse;
 import com.linclean.domain.link.entity.Category;
 import com.linclean.domain.link.entity.SavedLink;
 import com.linclean.domain.analysis.exception.AnalysisException;
@@ -419,6 +421,61 @@ class SavedLinkServiceTest {
                     .isInstanceOf(SavedLinkException.class)
                     .satisfies(ex -> assertThat(((SavedLinkException) ex).getErrorCode())
                             .isEqualTo(ErrorCode.SAVED_LINK_NOT_FOUND));
+        }
+    }
+
+    // ── updateTitle ───────────────────────────────────────────────────────
+
+    @Nested
+    class UpdateTitle {
+
+        @Test
+        void success() {
+            SavedLink link = makeSavedLink(10L, null);
+            given(savedLinkRepository.findByIdAndMember_Id(10L, 1L)).willReturn(Optional.of(link));
+            given(savedLinkRepository.existsByMember_IdAndTitleAndIdNot(1L, "새 제목", 10L)).willReturn(false);
+
+            SavedLinkTitleUpdateResponse response = savedLinkService.updateTitle(1L, 10L,
+                    new SavedLinkTitleUpdateRequest("새 제목"));
+
+            assertThat(response.id()).isEqualTo(10L);
+            assertThat(response.title()).isEqualTo("새 제목");
+        }
+
+        @Test
+        void sameTitle_success() {
+            SavedLink link = makeSavedLink(10L, null);
+            given(savedLinkRepository.findByIdAndMember_Id(10L, 1L)).willReturn(Optional.of(link));
+            given(savedLinkRepository.existsByMember_IdAndTitleAndIdNot(1L, "제목", 10L)).willReturn(false);
+
+            SavedLinkTitleUpdateResponse response = savedLinkService.updateTitle(1L, 10L,
+                    new SavedLinkTitleUpdateRequest("제목"));
+
+            assertThat(response.title()).isEqualTo("제목");
+        }
+
+        @Test
+        void notFound_throws() {
+            given(savedLinkRepository.findByIdAndMember_Id(99L, 1L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> savedLinkService.updateTitle(1L, 99L,
+                    new SavedLinkTitleUpdateRequest("새 제목")))
+                    .isInstanceOf(SavedLinkException.class)
+                    .satisfies(ex -> assertThat(((SavedLinkException) ex).getErrorCode())
+                            .isEqualTo(ErrorCode.SAVED_LINK_NOT_FOUND));
+        }
+
+        @Test
+        void titleDuplicate_throws() {
+            SavedLink link = makeSavedLink(10L, null);
+            given(savedLinkRepository.findByIdAndMember_Id(10L, 1L)).willReturn(Optional.of(link));
+            given(savedLinkRepository.existsByMember_IdAndTitleAndIdNot(1L, "중복 제목", 10L)).willReturn(true);
+
+            assertThatThrownBy(() -> savedLinkService.updateTitle(1L, 10L,
+                    new SavedLinkTitleUpdateRequest("중복 제목")))
+                    .isInstanceOf(SavedLinkException.class)
+                    .satisfies(ex -> assertThat(((SavedLinkException) ex).getErrorCode())
+                            .isEqualTo(ErrorCode.SAVED_LINK_TITLE_DUPLICATE));
         }
     }
 

--- a/src/test/java/com/linclean/domain/link/service/SavedLinkServiceTest.java
+++ b/src/test/java/com/linclean/domain/link/service/SavedLinkServiceTest.java
@@ -477,6 +477,21 @@ class SavedLinkServiceTest {
                     .satisfies(ex -> assertThat(((SavedLinkException) ex).getErrorCode())
                             .isEqualTo(ErrorCode.SAVED_LINK_TITLE_DUPLICATE));
         }
+
+        @Test
+        void concurrentTitleDuplicate_throwsTitleDuplicate() {
+            SavedLink link = makeSavedLink(10L, null);
+            given(savedLinkRepository.findByIdAndMember_Id(10L, 1L)).willReturn(Optional.of(link));
+            given(savedLinkRepository.existsByMember_IdAndTitleAndIdNot(1L, "새 제목", 10L)).willReturn(false);
+            org.mockito.BDDMockito.willThrow(new DataIntegrityViolationException("uq_saved_link_member_title"))
+                    .given(savedLinkRepository).flush();
+
+            assertThatThrownBy(() -> savedLinkService.updateTitle(1L, 10L,
+                    new SavedLinkTitleUpdateRequest("새 제목")))
+                    .isInstanceOf(SavedLinkException.class)
+                    .satisfies(ex -> assertThat(((SavedLinkException) ex).getErrorCode())
+                            .isEqualTo(ErrorCode.SAVED_LINK_TITLE_DUPLICATE));
+        }
     }
 
     // ── 헬퍼 ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
# 요약

저장 링크의 제목을 수정하는 API를 추가합니다.

- `PATCH /api/v1/saved-links/{id}/title` 엔드포인트 추가
- 동일 회원 내 중복 제목 요청 시 409 예외 처리 (자기 자신 제외)
- 동시 요청에 의한 DB 제약 위반도 500 대신 409로 변환 (`flush()` + `DataIntegrityViolationException` 처리)
- Swagger 400 응답 문서 추가
- 서비스 단위 테스트 및 컨트롤러 MockMvc 테스트 추가

## 테스트

### 기존 id = 21 인 테스트1
<img width="2864" height="74" alt="image" src="https://github.com/user-attachments/assets/8b8bd09b-523d-4f5a-9ccf-60f31062b680" />


### 테스트1 -> 이름 변경 테스트 변경
<img width="1432" height="736" alt="image" src="https://github.com/user-attachments/assets/8d665630-2d2d-4e8e-a615-46502fd65946" />

### 디비 변경 확인
<img width="1432" height="32" alt="image" src="https://github.com/user-attachments/assets/de38465f-8bd7-4463-bcc8-71646d7c291f" />


# 연관 이슈 및 Close 할 이슈 작성

close #34

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?