### PR TITLE
[REFACTOR] HandlerMethodValidationException 변경

### DIFF
--- a/src/main/java/com/linclean/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/linclean/global/exception/GlobalExceptionHandler.java
@@ -86,8 +86,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HandlerMethodValidationException.class)
     public ResponseEntity<ErrorResponse> handleMethodValidation(HandlerMethodValidationException e) {
-        String message = e.getAllValidationResults().stream()
-                .flatMap(r -> r.getResolvableErrors().stream())
+        String message = e.getAllErrors().stream()
                 .findFirst()
                 .map(err -> err.getDefaultMessage())
                 .orElse("요청 파라미터가 유효하지 않습니다.");


### PR DESCRIPTION
# 요약
Spring Boot 3.5(Spring Framework 6.2) 업그레이드로 인해 `HandlerMethodValidationException.getAllValidationResults()`가 제거됨에 따라, `getAllErrors()`로 교체합니다.

<img width="2972" height="1300" alt="image" src="https://github.com/user-attachments/assets/22844364-616c-43c0-a9ee-a092f1bf9f80" />


# 연관 이슈 및 Close 할 이슈 작성
close #38

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?