### PR TITLE
[FEATURE] 등급 현황 api 개발

### DIFF
--- a/src/main/java/com/linclean/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/linclean/domain/analysis/controller/AnalysisController.java
@@ -2,7 +2,9 @@ package com.linclean.domain.analysis.controller;
 
 import com.linclean.domain.analysis.dto.request.AnalysisRequest;
 import com.linclean.domain.analysis.dto.response.AnalysisResponse;
+import com.linclean.domain.analysis.dto.response.VerdictStatisticsResponse;
 import com.linclean.domain.analysis.service.AnalysisService;
+import com.linclean.domain.analysis.service.VerdictStatisticsService;
 import com.linclean.global.web.ApiResponse;
 import com.linclean.security.MemberPrincipal;
 import jakarta.validation.Valid;
@@ -25,6 +27,7 @@ import java.util.UUID;
 public class AnalysisController implements AnalysisControllerDocs {
 
     private final AnalysisService analysisService;
+    private final VerdictStatisticsService verdictStatisticsService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<AnalysisResponse>> requestAnalysis(
@@ -32,6 +35,12 @@ public class AnalysisController implements AnalysisControllerDocs {
             @Valid @RequestBody AnalysisRequest request) {
         AnalysisResponse response = analysisService.requestAnalysis(principal.memberId(), request);
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse.of(response));
+    }
+
+    @GetMapping("/statistics")
+    public ResponseEntity<ApiResponse<VerdictStatisticsResponse>> getVerdictStatistics() {
+        VerdictStatisticsResponse response = verdictStatisticsService.getVerdictStatistics();
+        return ResponseEntity.ok(ApiResponse.of(response));
     }
 
     @GetMapping("/{analysisId}")

--- a/src/main/java/com/linclean/domain/analysis/controller/AnalysisControllerDocs.java
+++ b/src/main/java/com/linclean/domain/analysis/controller/AnalysisControllerDocs.java
@@ -2,6 +2,7 @@ package com.linclean.domain.analysis.controller;
 
 import com.linclean.domain.analysis.dto.request.AnalysisRequest;
 import com.linclean.domain.analysis.dto.response.AnalysisResponse;
+import com.linclean.domain.analysis.dto.response.VerdictStatisticsResponse;
 import com.linclean.global.exception.ErrorResponse;
 import com.linclean.global.web.ApiResponse;
 import com.linclean.security.MemberPrincipal;
@@ -21,6 +22,10 @@ import java.util.UUID;
 
 @Tag(name = "Analysis", description = "URL 분석 API")
 public interface AnalysisControllerDocs {
+
+    @Operation(summary = "verdict 통계 조회", description = "전체 분석 결과의 verdict(safe/caution/danger) 건수를 반환합니다. 인증 불필요.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    ResponseEntity<ApiResponse<VerdictStatisticsResponse>> getVerdictStatistics();
 
     @Operation(summary = "URL 분석 요청", description = "URL 안전성 분석을 요청합니다. 분석은 비동기로 수행됩니다.")
     @ApiResponses({

--- a/src/main/java/com/linclean/domain/analysis/dto/response/VerdictStatisticsResponse.java
+++ b/src/main/java/com/linclean/domain/analysis/dto/response/VerdictStatisticsResponse.java
@@ -1,0 +1,50 @@
+package com.linclean.domain.analysis.dto.response;
+
+import com.linclean.domain.analysis.entity.Verdict;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class VerdictStatisticsResponse {
+
+    private final long safe;
+    private final long caution;
+    private final long danger;
+
+    public static VerdictStatisticsResponse from(Map<String, String> redisHash) {
+        return new VerdictStatisticsResponse(
+                parseLong(redisHash.get(Verdict.SAFE.name())),
+                parseLong(redisHash.get(Verdict.CAUTION.name())),
+                parseLong(redisHash.get(Verdict.DANGER.name()))
+        );
+    }
+
+    public static VerdictStatisticsResponse from(List<Object[]> dbResult) {
+        Map<Verdict, Long> counts = new EnumMap<>(Verdict.class);
+        for (Verdict v : Verdict.values()) {
+            counts.put(v, 0L);
+        }
+        for (Object[] row : dbResult) {
+            counts.put((Verdict) row[0], (Long) row[1]);
+        }
+        return new VerdictStatisticsResponse(
+                counts.get(Verdict.SAFE),
+                counts.get(Verdict.CAUTION),
+                counts.get(Verdict.DANGER)
+        );
+    }
+
+    private static long parseLong(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+}

--- a/src/main/java/com/linclean/domain/analysis/repository/AnalysisRepository.java
+++ b/src/main/java/com/linclean/domain/analysis/repository/AnalysisRepository.java
@@ -2,8 +2,13 @@ package com.linclean.domain.analysis.repository;
 
 import com.linclean.domain.analysis.entity.Analysis;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface AnalysisRepository extends JpaRepository<Analysis, UUID> {
+
+    @Query("SELECT a.verdict, COUNT(a) FROM Analysis a WHERE a.verdict IS NOT NULL GROUP BY a.verdict")
+    List<Object[]> countGroupByVerdict();
 }

--- a/src/main/java/com/linclean/domain/analysis/service/VerdictStatisticsService.java
+++ b/src/main/java/com/linclean/domain/analysis/service/VerdictStatisticsService.java
@@ -74,12 +74,16 @@ public class VerdictStatisticsService {
         hashMap.put(Verdict.CAUTION.name(), String.valueOf(response.getCaution()));
         hashMap.put(Verdict.DANGER.name(), String.valueOf(response.getDanger()));
 
-        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
-            StringRedisConnection conn = (StringRedisConnection) connection;
-            conn.hMSet(CACHE_KEY, hashMap);
-            conn.expire(CACHE_KEY, CACHE_TTL.getSeconds());
-            return null;
-        });
+        try {
+            redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+                StringRedisConnection conn = (StringRedisConnection) connection;
+                conn.hMSet(CACHE_KEY, hashMap);
+                conn.expire(CACHE_KEY, CACHE_TTL.getSeconds());
+                return null;
+            });
+        } catch (Exception e) {
+            log.warn("Redis 캐시 쓰기 실패, DB 결과 반환", e);
+        }
 
         return response;
     }

--- a/src/main/java/com/linclean/domain/analysis/service/VerdictStatisticsService.java
+++ b/src/main/java/com/linclean/domain/analysis/service/VerdictStatisticsService.java
@@ -1,0 +1,86 @@
+package com.linclean.domain.analysis.service;
+
+import com.linclean.domain.analysis.dto.response.VerdictStatisticsResponse;
+import com.linclean.domain.analysis.entity.Verdict;
+import com.linclean.domain.analysis.repository.AnalysisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VerdictStatisticsService {
+
+    private static final String CACHE_KEY = "analysis:verdict:counts";
+    private static final Duration CACHE_TTL = Duration.ofMinutes(90);
+
+    private final AnalysisRepository analysisRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    public VerdictStatisticsResponse getVerdictStatistics() {
+        try {
+            HashOperations<String, String, String> ops = redisTemplate.opsForHash();
+            Map<String, String> cached = ops.entries(CACHE_KEY);
+            if (!cached.isEmpty()) {
+                return VerdictStatisticsResponse.from(cached);
+            }
+        } catch (Exception e) {
+            log.warn("Redis 조회 실패, DB fallback 수행", e);
+            return VerdictStatisticsResponse.from(analysisRepository.countGroupByVerdict());
+        }
+        return queryAndCache();
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        refreshCache();
+    }
+
+    @Scheduled(fixedRate = 50, initialDelay = 50, timeUnit = TimeUnit.MINUTES)
+    public void scheduledRefresh() {
+        refreshCache();
+    }
+
+    private void refreshCache() {
+        log.info("verdict 통계 캐시 갱신 시작");
+        try {
+            queryAndCache();
+            log.info("verdict 통계 캐시 갱신 완료");
+        } catch (Exception e) {
+            log.error("verdict 통계 캐시 갱신 실패", e);
+        }
+    }
+
+    private VerdictStatisticsResponse queryAndCache() {
+        List<Object[]> dbResult = analysisRepository.countGroupByVerdict();
+        VerdictStatisticsResponse response = VerdictStatisticsResponse.from(dbResult);
+
+        Map<String, String> hashMap = new HashMap<>();
+        hashMap.put(Verdict.SAFE.name(), String.valueOf(response.getSafe()));
+        hashMap.put(Verdict.CAUTION.name(), String.valueOf(response.getCaution()));
+        hashMap.put(Verdict.DANGER.name(), String.valueOf(response.getDanger()));
+
+        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            StringRedisConnection conn = (StringRedisConnection) connection;
+            conn.hMSet(CACHE_KEY, hashMap);
+            conn.expire(CACHE_KEY, CACHE_TTL.getSeconds());
+            return null;
+        });
+
+        return response;
+    }
+}

--- a/src/main/java/com/linclean/global/config/SecurityConfig.java
+++ b/src/main/java/com/linclean/global/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/v1/terms/**"
+                                "/api/v1/terms/**",
+                                "/api/v1/analyses/statistics"
                         ).permitAll()
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/clerk-test.html").permitAll()

--- a/src/test/java/com/linclean/domain/analysis/controller/VerdictStatisticsControllerTest.java
+++ b/src/test/java/com/linclean/domain/analysis/controller/VerdictStatisticsControllerTest.java
@@ -1,0 +1,52 @@
+package com.linclean.domain.analysis.controller;
+
+import com.linclean.domain.analysis.dto.response.VerdictStatisticsResponse;
+import com.linclean.domain.analysis.entity.Verdict;
+import com.linclean.domain.analysis.service.AnalysisService;
+import com.linclean.domain.analysis.service.VerdictStatisticsService;
+import com.linclean.security.MemberSyncService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        value = AnalysisController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class, OAuth2ResourceServerAutoConfiguration.class}
+)
+class VerdictStatisticsControllerTest {
+
+    @Autowired MockMvc mockMvc;
+
+    @MockBean VerdictStatisticsService verdictStatisticsService;
+    @MockBean AnalysisService analysisService;
+    @MockBean MemberSyncService memberSyncService;
+
+    @Test
+    void getVerdictStatistics_returns200WithCounts() throws Exception {
+        List<Object[]> dbResult = List.<Object[]>of(
+                new Object[]{Verdict.SAFE, 100L},
+                new Object[]{Verdict.CAUTION, 20L},
+                new Object[]{Verdict.DANGER, 5L}
+        );
+        given(verdictStatisticsService.getVerdictStatistics())
+                .willReturn(VerdictStatisticsResponse.from(dbResult));
+
+        mockMvc.perform(get("/api/v1/analyses/statistics"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.safe").value(100))
+                .andExpect(jsonPath("$.data.caution").value(20))
+                .andExpect(jsonPath("$.data.danger").value(5));
+    }
+}

--- a/src/test/java/com/linclean/domain/analysis/dto/response/VerdictStatisticsResponseTest.java
+++ b/src/test/java/com/linclean/domain/analysis/dto/response/VerdictStatisticsResponseTest.java
@@ -43,7 +43,9 @@ class VerdictStatisticsResponseTest {
 
             VerdictStatisticsResponse response = VerdictStatisticsResponse.from(hash);
 
+            assertThat(response.getSafe()).isEqualTo(10);
             assertThat(response.getCaution()).isEqualTo(0);
+            assertThat(response.getDanger()).isEqualTo(5);
         }
 
         @Test

--- a/src/test/java/com/linclean/domain/analysis/dto/response/VerdictStatisticsResponseTest.java
+++ b/src/test/java/com/linclean/domain/analysis/dto/response/VerdictStatisticsResponseTest.java
@@ -1,0 +1,97 @@
+package com.linclean.domain.analysis.dto.response;
+
+import com.linclean.domain.analysis.entity.Verdict;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VerdictStatisticsResponseTest {
+
+    @Nested
+    class FromRedisHash {
+
+        @Test
+        void allVerdictsPresent_mapsCorrectly() {
+            Map<String, String> hash = Map.of("SAFE", "100", "CAUTION", "20", "DANGER", "5");
+
+            VerdictStatisticsResponse response = VerdictStatisticsResponse.from(hash);
+
+            assertThat(response.getSafe()).isEqualTo(100);
+            assertThat(response.getCaution()).isEqualTo(20);
+            assertThat(response.getDanger()).isEqualTo(5);
+        }
+
+        @Test
+        void missingKey_returnsZero() {
+            Map<String, String> hash = Map.of("SAFE", "50");
+
+            VerdictStatisticsResponse response = VerdictStatisticsResponse.from(hash);
+
+            assertThat(response.getSafe()).isEqualTo(50);
+            assertThat(response.getCaution()).isEqualTo(0);
+            assertThat(response.getDanger()).isEqualTo(0);
+        }
+
+        @Test
+        void emptyString_returnsZero() {
+            Map<String, String> hash = Map.of("SAFE", "10", "CAUTION", "", "DANGER", "5");
+
+            VerdictStatisticsResponse response = VerdictStatisticsResponse.from(hash);
+
+            assertThat(response.getCaution()).isEqualTo(0);
+        }
+
+        @Test
+        void nonNumericValue_returnsZero() {
+            Map<String, String> hash = Map.of("SAFE", "invalid", "CAUTION", "20", "DANGER", "5");
+
+            VerdictStatisticsResponse response = VerdictStatisticsResponse.from(hash);
+
+            assertThat(response.getSafe()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    class FromDbResult {
+
+        @Test
+        void allVerdictsPresent_mapsCorrectly() {
+            List<Object[]> dbResult = List.<Object[]>of(
+                    new Object[]{Verdict.SAFE, 100L},
+                    new Object[]{Verdict.CAUTION, 20L},
+                    new Object[]{Verdict.DANGER, 5L}
+            );
+
+            VerdictStatisticsResponse response = VerdictStatisticsResponse.from(dbResult);
+
+            assertThat(response.getSafe()).isEqualTo(100);
+            assertThat(response.getCaution()).isEqualTo(20);
+            assertThat(response.getDanger()).isEqualTo(5);
+        }
+
+        @Test
+        void emptyList_allZero() {
+            VerdictStatisticsResponse response = VerdictStatisticsResponse.from(List.of());
+
+            assertThat(response.getSafe()).isEqualTo(0);
+            assertThat(response.getCaution()).isEqualTo(0);
+            assertThat(response.getDanger()).isEqualTo(0);
+        }
+
+        @Test
+        void partialResult_missingVerdictIsZero() {
+            List<Object[]> dbResult = Collections.singletonList(new Object[]{Verdict.DANGER, 3L});
+
+            VerdictStatisticsResponse response = VerdictStatisticsResponse.from(dbResult);
+
+            assertThat(response.getDanger()).isEqualTo(3);
+            assertThat(response.getSafe()).isEqualTo(0);
+            assertThat(response.getCaution()).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/com/linclean/domain/analysis/service/VerdictStatisticsServiceTest.java
+++ b/src/test/java/com/linclean/domain/analysis/service/VerdictStatisticsServiceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -141,7 +142,7 @@ class VerdictStatisticsServiceTest {
             given(analysisRepository.countGroupByVerdict())
                     .willThrow(new RuntimeException("DB down"));
 
-            verdictStatisticsService.scheduledRefresh();
+            assertDoesNotThrow(() -> verdictStatisticsService.scheduledRefresh());
         }
 
         @Test
@@ -151,6 +152,7 @@ class VerdictStatisticsServiceTest {
             verdictStatisticsService.onApplicationReady();
 
             then(analysisRepository).should().countGroupByVerdict();
+            then(redisTemplate).should().executePipelined(any(RedisCallback.class));
         }
     }
 }

--- a/src/test/java/com/linclean/domain/analysis/service/VerdictStatisticsServiceTest.java
+++ b/src/test/java/com/linclean/domain/analysis/service/VerdictStatisticsServiceTest.java
@@ -1,0 +1,156 @@
+package com.linclean.domain.analysis.service;
+
+import com.linclean.domain.analysis.dto.response.VerdictStatisticsResponse;
+import com.linclean.domain.analysis.entity.Verdict;
+import com.linclean.domain.analysis.repository.AnalysisRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class VerdictStatisticsServiceTest {
+
+    @Mock AnalysisRepository analysisRepository;
+    @Mock StringRedisTemplate redisTemplate;
+    @InjectMocks VerdictStatisticsService verdictStatisticsService;
+
+    private HashOperations<String, String, String> hashOps;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        hashOps = mock(HashOperations.class);
+    }
+
+    @Nested
+    class GetVerdictStatistics {
+
+        @BeforeEach
+        void setUpHashOps() {
+            doReturn(hashOps).when(redisTemplate).opsForHash();
+        }
+
+        @Test
+        void cacheHit_returnsFromRedisWithoutDbCall() {
+            given(hashOps.entries("analysis:verdict:counts"))
+                    .willReturn(Map.of("SAFE", "100", "CAUTION", "20", "DANGER", "5"));
+
+            VerdictStatisticsResponse response = verdictStatisticsService.getVerdictStatistics();
+
+            assertThat(response.getSafe()).isEqualTo(100);
+            assertThat(response.getCaution()).isEqualTo(20);
+            assertThat(response.getDanger()).isEqualTo(5);
+            then(analysisRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        void cacheMiss_queriesDbAndCachesResult() {
+            List<Object[]> dbResult = List.<Object[]>of(
+                    new Object[]{Verdict.SAFE, 200L},
+                    new Object[]{Verdict.CAUTION, 30L},
+                    new Object[]{Verdict.DANGER, 10L}
+            );
+            given(hashOps.entries("analysis:verdict:counts")).willReturn(Map.of());
+            given(analysisRepository.countGroupByVerdict()).willReturn(dbResult);
+
+            VerdictStatisticsResponse response = verdictStatisticsService.getVerdictStatistics();
+
+            assertThat(response.getSafe()).isEqualTo(200);
+            assertThat(response.getCaution()).isEqualTo(30);
+            assertThat(response.getDanger()).isEqualTo(10);
+            then(redisTemplate).should().executePipelined(any(RedisCallback.class));
+        }
+
+        @Test
+        void cacheMiss_partialDbResult_zeroForMissingVerdict() {
+            given(hashOps.entries("analysis:verdict:counts")).willReturn(Map.of());
+            given(analysisRepository.countGroupByVerdict())
+                    .willReturn(Collections.singletonList(new Object[]{Verdict.SAFE, 50L}));
+
+            VerdictStatisticsResponse response = verdictStatisticsService.getVerdictStatistics();
+
+            assertThat(response.getSafe()).isEqualTo(50);
+            assertThat(response.getCaution()).isEqualTo(0);
+            assertThat(response.getDanger()).isEqualTo(0);
+        }
+
+        @Test
+        void redisReadFailure_fallsBackToDbDirectly() {
+            given(hashOps.entries("analysis:verdict:counts"))
+                    .willThrow(new RuntimeException("Redis connection refused"));
+            given(analysisRepository.countGroupByVerdict())
+                    .willReturn(Collections.singletonList(new Object[]{Verdict.SAFE, 10L}));
+
+            VerdictStatisticsResponse response = verdictStatisticsService.getVerdictStatistics();
+
+            assertThat(response.getSafe()).isEqualTo(10);
+            then(redisTemplate).should(never()).executePipelined(any(RedisCallback.class));
+        }
+
+        @Test
+        void redisWriteFailure_returnsDbResultWithoutThrowing() {
+            given(hashOps.entries("analysis:verdict:counts")).willReturn(Map.of());
+            given(analysisRepository.countGroupByVerdict())
+                    .willReturn(Collections.singletonList(new Object[]{Verdict.DANGER, 3L}));
+            given(redisTemplate.executePipelined(any(RedisCallback.class)))
+                    .willThrow(new RuntimeException("Redis write failed"));
+
+            VerdictStatisticsResponse response = verdictStatisticsService.getVerdictStatistics();
+
+            assertThat(response.getDanger()).isEqualTo(3);
+            assertThat(response.getSafe()).isEqualTo(0);
+            assertThat(response.getCaution()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    class RefreshCache {
+
+        @Test
+        void scheduledRefresh_queriesDbAndCaches() {
+            given(analysisRepository.countGroupByVerdict())
+                    .willReturn(Collections.singletonList(new Object[]{Verdict.SAFE, 100L}));
+
+            verdictStatisticsService.scheduledRefresh();
+
+            then(analysisRepository).should().countGroupByVerdict();
+            then(redisTemplate).should().executePipelined(any(RedisCallback.class));
+        }
+
+        @Test
+        void scheduledRefresh_dbFailure_doesNotThrow() {
+            given(analysisRepository.countGroupByVerdict())
+                    .willThrow(new RuntimeException("DB down"));
+
+            verdictStatisticsService.scheduledRefresh();
+        }
+
+        @Test
+        void onApplicationReady_queriesDbAndCaches() {
+            given(analysisRepository.countGroupByVerdict()).willReturn(List.of());
+
+            verdictStatisticsService.onApplicationReady();
+
+            then(analysisRepository).should().countGroupByVerdict();
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

전체 분석 결과의 verdict(safe/caution/danger) 건수를 집계해 반환하는 통계 API를 구현했습니다.
메인 홈 화면 등 고빈도 호출 경로에 포함되는 API이므로 Redis 캐싱을 함께 적용했습니다.

## 엔드포인트

```
GET /api/v1/analyses/statistics
```

- 인증 불필요 (집계 통계, 개인정보 없음)
- 응답: `{ "data": { "safe": N, "caution": N, "danger": N } }`

---

## 캐싱 전략 선택 배경

구현 전 아래 3가지 방식을 검토했습니다.

### Option A: Cache-Aside (Lazy Loading) + TTL

```
API 요청 → Redis 조회
  ├── Hit  → 즉시 반환
  └── Miss → DB GROUP BY → Redis 저장 (TTL 1시간) → 반환
```

단순하고 이해하기 쉬운 구조입니다.  
**단점**: TTL 만료 시점에 다수의 동시 요청이 모두 cache miss를 보고 DB를 동시에 조회하는 **Thundering Herd** 문제가 발생합니다.  
트래픽이 낮은 내부 대시보드라면 허용 가능하지만, **메인 홈 화면에 포함되는 고빈도 API**이므로 부적합하다고 판단했습니다.

### Option B: 이벤트 드리븐 (분석 콜백 시 Redis 카운터 증감)

```
분석 콜백 수신 → Redis INCR verdict:{safe|caution|danger}
API 요청      → Redis GET 즉시 반환
```

항상 실시간에 가까운 정확한 값을 제공합니다.  
**단점**:
- 서버 재시작·Redis 장애 복구 시 초기값 재적재 로직이 별도로 필요합니다.
- `AnalysisCallbackService`에 Redis 의존성이 추가되어 단일 책임 원칙이 흐트러집니다.
- 1시간 staleness가 이미 허용된 상황에서 실시간 정확도를 추구하는 것은 오버엔지니어링입니다.

### Option C: Scheduled Pre-warming + Cache-Aside 폴백 ✅ 채택

```
[Scheduled - 50분마다]
  └── DB GROUP BY → Redis HSET analysis:verdict:counts (TTL 90분)

[API 요청]
  ├── Redis Hit  → 즉시 반환
  └── Redis Miss → DB 조회 → Redis 갱신 → 반환  (재시작·장애 복구용 폴백)
```

채택 이유:
- **Thundering Herd 방지**: 스케줄러가 캐시를 항상 warm하게 유지하므로 동시 cache miss가 발생하지 않습니다.
- **자동 복구**: Redis 재시작·장애 시 Cache-Aside 폴백으로 정상 동작을 유지합니다.
- **책임 분리**: 분석 콜백 흐름에 캐시 로직을 끼워 넣지 않습니다.
- **단순성**: 분산 락 없이 충분한 안정성을 확보합니다.
- TTL(90분) > 스케줄러 주기(50분)로 설정해 스케줄러 실패 시에도 일정 시간 stale 데이터를 유지하는 안전망을 마련했습니다.

---

## 구현 세부사항

| 항목 | 내용 |
|------|------|
| Redis 키 | `analysis:verdict:counts` (Hash, 필드: SAFE / CAUTION / DANGER) |
| TTL | 90분 |
| 스케줄러 주기 | 50분 (`initialDelay` 동일 적용) |
| 기동 시 pre-warm | `@EventListener(ApplicationReadyEvent.class)` |
| Redis 읽기 장애 | try-catch → DB 직접 조회 폴백 |
| Redis 쓰기 장애 | try-catch → DB 결과 그대로 반환 (500 방지) |
| 원자성 | `executePipelined()` 로 HSET + EXPIRE 묶음 처리 |

## 변경 파일

- `AnalysisRepository` — `countGroupByVerdict()` JPQL 쿼리 추가
- `VerdictStatisticsResponse` — Redis 해시 / DB 결과 두 소스에서 변환하는 DTO
- `VerdictStatisticsService` — 캐싱 서비스 (Cache-Aside + 스케줄러)
- `AnalysisController` / `AnalysisControllerDocs` — 엔드포인트 추가
- `SecurityConfig` — 통계 엔드포인트 `permitAll` 추가

## 테스트

- `VerdictStatisticsServiceTest` — 캐시 히트/미스, Redis 읽기·쓰기 장애 fallback, 스케줄러 동작
- `VerdictStatisticsResponseTest` — Redis 해시 및 DB 결과 변환, 비정상 값 방어 처리
- `VerdictStatisticsControllerTest` — `GET /api/v1/analyses/statistics` 응답 검증

### 스웨거 정상 응답 확인
<img width="1419" height="883" alt="image" src="https://github.com/user-attachments/assets/ef395324-28f2-459a-a3fc-6d393dfdb2ce" />

### valkey 캐싱 성공 확인
<img width="1030" height="268" alt="image" src="https://github.com/user-attachments/assets/be9d78d0-8485-48aa-af72-18fc162c4b8e" />
