### PR TITLE
[Feat] 저장된 URL 중복 체크 API 추가

### DIFF
--- a/src/main/java/com/linclean/domain/link/controller/SavedLinkController.java
+++ b/src/main/java/com/linclean/domain/link/controller/SavedLinkController.java
@@ -9,6 +9,7 @@ import com.linclean.domain.link.dto.response.CategoryUpdateResponse;
 import com.linclean.domain.link.dto.response.SavedLinkListResponse;
 import com.linclean.domain.link.dto.response.SavedLinkResponse;
 import com.linclean.domain.link.dto.response.SavedLinkTitleUpdateResponse;
+import com.linclean.domain.link.dto.response.UrlCheckResponse;
 import com.linclean.domain.link.service.SavedLinkService;
 import com.linclean.global.web.ApiResponse;
 import com.linclean.security.MemberPrincipal;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -71,6 +73,13 @@ public class SavedLinkController implements SavedLinkControllerDocs {
             @PathVariable Long id,
             @RequestBody CategoryUpdateRequest request) {
         return ResponseEntity.ok(ApiResponse.of(savedLinkService.updateCategory(principal.memberId(), id, request)));
+    }
+
+    @GetMapping("/check")
+    public ResponseEntity<ApiResponse<UrlCheckResponse>> checkUrl(
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @RequestParam String url) {
+        return ResponseEntity.ok(ApiResponse.of(savedLinkService.checkUrl(principal.memberId(), url)));
     }
 
     @PatchMapping("/{id}/title")

--- a/src/main/java/com/linclean/domain/link/controller/SavedLinkController.java
+++ b/src/main/java/com/linclean/domain/link/controller/SavedLinkController.java
@@ -17,6 +17,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -79,6 +80,9 @@ public class SavedLinkController implements SavedLinkControllerDocs {
     public ResponseEntity<ApiResponse<UrlCheckResponse>> checkUrl(
             @AuthenticationPrincipal MemberPrincipal principal,
             @RequestParam String url) {
+        if (url.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "url 파라미터가 비어 있습니다.");
+        }
         return ResponseEntity.ok(ApiResponse.of(savedLinkService.checkUrl(principal.memberId(), url)));
     }
 

--- a/src/main/java/com/linclean/domain/link/controller/SavedLinkControllerDocs.java
+++ b/src/main/java/com/linclean/domain/link/controller/SavedLinkControllerDocs.java
@@ -9,6 +9,7 @@ import com.linclean.domain.link.dto.response.CategoryUpdateResponse;
 import com.linclean.domain.link.dto.response.SavedLinkListResponse;
 import com.linclean.domain.link.dto.response.SavedLinkResponse;
 import com.linclean.domain.link.dto.response.SavedLinkTitleUpdateResponse;
+import com.linclean.domain.link.dto.response.UrlCheckResponse;
 import com.linclean.global.exception.ErrorResponse;
 import com.linclean.global.web.ApiResponse;
 import com.linclean.security.MemberPrincipal;
@@ -24,6 +25,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "SavedLink", description = "저장 링크 API")
 public interface SavedLinkControllerDocs {
@@ -88,6 +90,15 @@ public interface SavedLinkControllerDocs {
             @AuthenticationPrincipal MemberPrincipal principal,
             @Parameter(description = "저장 링크 ID") @PathVariable Long id,
             @RequestBody CategoryUpdateRequest request
+    );
+
+    @Operation(summary = "URL 중복 체크", description = "입력한 URL이 이미 저장된 링크에 존재하는지 확인합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<ApiResponse<UrlCheckResponse>> checkUrl(
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @Parameter(description = "확인할 URL") @RequestParam String url
     );
 
     @Operation(summary = "제목 변경", description = "저장 링크의 제목을 변경합니다. 동일 회원 내 중복된 제목은 허용하지 않습니다.")

--- a/src/main/java/com/linclean/domain/link/controller/SavedLinkControllerDocs.java
+++ b/src/main/java/com/linclean/domain/link/controller/SavedLinkControllerDocs.java
@@ -94,7 +94,11 @@ public interface SavedLinkControllerDocs {
 
     @Operation(summary = "URL 중복 체크", description = "입력한 URL이 이미 저장된 링크에 존재하는지 확인합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "url 파라미터 누락 또는 빈 문자열",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<ApiResponse<UrlCheckResponse>> checkUrl(
             @AuthenticationPrincipal MemberPrincipal principal,

--- a/src/main/java/com/linclean/domain/link/dto/response/UrlCheckResponse.java
+++ b/src/main/java/com/linclean/domain/link/dto/response/UrlCheckResponse.java
@@ -1,0 +1,3 @@
+package com.linclean.domain.link.dto.response;
+
+public record UrlCheckResponse(boolean exists) {}

--- a/src/main/java/com/linclean/domain/link/repository/SavedLinkRepository.java
+++ b/src/main/java/com/linclean/domain/link/repository/SavedLinkRepository.java
@@ -16,6 +16,8 @@ public interface SavedLinkRepository extends JpaRepository<SavedLink, Long> {
 
     boolean existsByMember_IdAndAnalysis_AnalysisId(Long memberId, java.util.UUID analysisId);
 
+    boolean existsByMember_IdAndAnalysis_OriginalUrl(Long memberId, String url);
+
     boolean existsByMember_IdAndTitle(Long memberId, String title);
 
     boolean existsByMember_IdAndTitleAndIdNot(Long memberId, String title, Long id);

--- a/src/main/java/com/linclean/domain/link/service/SavedLinkService.java
+++ b/src/main/java/com/linclean/domain/link/service/SavedLinkService.java
@@ -14,6 +14,7 @@ import com.linclean.domain.link.dto.response.CategoryUpdateResponse;
 import com.linclean.domain.link.dto.response.SavedLinkListResponse;
 import com.linclean.domain.link.dto.response.SavedLinkResponse;
 import com.linclean.domain.link.dto.response.SavedLinkTitleUpdateResponse;
+import com.linclean.domain.link.dto.response.UrlCheckResponse;
 import com.linclean.domain.link.entity.Category;
 import com.linclean.domain.link.entity.SavedLink;
 import com.linclean.domain.link.exception.SavedLinkException;
@@ -172,5 +173,11 @@ public class SavedLinkService {
     private String encodeCursor(Long id) {
         return Base64.getUrlEncoder().withoutPadding()
                 .encodeToString(id.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Transactional(readOnly = true)
+    public UrlCheckResponse checkUrl(Long memberId, String url) {
+        boolean exists = savedLinkRepository.existsByMember_IdAndAnalysis_OriginalUrl(memberId, url);
+        return new UrlCheckResponse(exists);
     }
 }

--- a/src/main/java/com/linclean/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/linclean/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
@@ -82,6 +83,12 @@ public class GlobalExceptionHandler {
         log.debug("공지사항 도메인 오류: {}", e.getMessage());
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(ErrorResponse.of(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingParam(MissingServletRequestParameterException e) {
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse("VALIDATION_ERROR", e.getParameterName() + " 파라미터가 필요합니다.", Instant.now()));
     }
 
     @ExceptionHandler(HandlerMethodValidationException.class)

--- a/src/test/java/com/linclean/domain/link/controller/SavedLinkControllerTest.java
+++ b/src/test/java/com/linclean/domain/link/controller/SavedLinkControllerTest.java
@@ -421,6 +421,22 @@ class SavedLinkControllerTest {
                 .andExpect(jsonPath("$.data.exists").value(false));
     }
 
+    @Test
+    void checkUrl_missingUrlParam_returns400() throws Exception {
+        mockMvc.perform(get("/api/v1/saved-links/check")
+                        .with(authentication(AUTH)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void checkUrl_blankUrl_returns400() throws Exception {
+        mockMvc.perform(get("/api/v1/saved-links/check")
+                        .with(authentication(AUTH))
+                        .param("url", ""))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
     // ── PATCH /api/v1/saved-links/{id}/title ─────────────────────────────
 
     @Test

--- a/src/test/java/com/linclean/domain/link/controller/SavedLinkControllerTest.java
+++ b/src/test/java/com/linclean/domain/link/controller/SavedLinkControllerTest.java
@@ -9,6 +9,7 @@ import com.linclean.domain.link.dto.response.CategoryUpdateResponse;
 import com.linclean.domain.link.dto.response.SavedLinkListResponse;
 import com.linclean.domain.link.dto.response.SavedLinkResponse;
 import com.linclean.domain.link.dto.response.SavedLinkTitleUpdateResponse;
+import com.linclean.domain.link.dto.response.UrlCheckResponse;
 import com.linclean.domain.link.exception.SavedLinkException;
 import com.linclean.domain.link.service.SavedLinkService;
 import com.linclean.global.exception.ErrorCode;
@@ -392,6 +393,32 @@ class SavedLinkControllerTest {
                         .content("{\"categoryId\": 99}"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(ErrorCode.CATEGORY_NOT_FOUND.getCode()));
+    }
+
+    // ── GET /api/v1/saved-links/check ────────────────────────────────────
+
+    @Test
+    void checkUrl_existingUrl_returns200WithTrue() throws Exception {
+        given(savedLinkService.checkUrl(1L, "https://example.com"))
+                .willReturn(new UrlCheckResponse(true));
+
+        mockMvc.perform(get("/api/v1/saved-links/check")
+                        .with(authentication(AUTH))
+                        .param("url", "https://example.com"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.exists").value(true));
+    }
+
+    @Test
+    void checkUrl_nonExistingUrl_returns200WithFalse() throws Exception {
+        given(savedLinkService.checkUrl(1L, "https://unknown.com"))
+                .willReturn(new UrlCheckResponse(false));
+
+        mockMvc.perform(get("/api/v1/saved-links/check")
+                        .with(authentication(AUTH))
+                        .param("url", "https://unknown.com"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.exists").value(false));
     }
 
     // ── PATCH /api/v1/saved-links/{id}/title ─────────────────────────────

--- a/src/test/java/com/linclean/domain/link/service/SavedLinkServiceTest.java
+++ b/src/test/java/com/linclean/domain/link/service/SavedLinkServiceTest.java
@@ -13,6 +13,7 @@ import com.linclean.domain.link.dto.response.CategoryUpdateResponse;
 import com.linclean.domain.link.dto.response.SavedLinkListResponse;
 import com.linclean.domain.link.dto.response.SavedLinkResponse;
 import com.linclean.domain.link.dto.response.SavedLinkTitleUpdateResponse;
+import com.linclean.domain.link.dto.response.UrlCheckResponse;
 import com.linclean.domain.link.entity.Category;
 import com.linclean.domain.link.entity.SavedLink;
 import com.linclean.domain.analysis.exception.AnalysisException;
@@ -491,6 +492,32 @@ class SavedLinkServiceTest {
                     .isInstanceOf(SavedLinkException.class)
                     .satisfies(ex -> assertThat(((SavedLinkException) ex).getErrorCode())
                             .isEqualTo(ErrorCode.SAVED_LINK_TITLE_DUPLICATE));
+        }
+    }
+
+    // ── checkUrl ──────────────────────────────────────────────────────────
+
+    @Nested
+    class CheckUrl {
+
+        @Test
+        void existingUrl_returnsTrue() {
+            given(savedLinkRepository.existsByMember_IdAndAnalysis_OriginalUrl(1L, "https://example.com"))
+                    .willReturn(true);
+
+            UrlCheckResponse response = savedLinkService.checkUrl(1L, "https://example.com");
+
+            assertThat(response.exists()).isTrue();
+        }
+
+        @Test
+        void nonExistingUrl_returnsFalse() {
+            given(savedLinkRepository.existsByMember_IdAndAnalysis_OriginalUrl(1L, "https://unknown.com"))
+                    .willReturn(false);
+
+            UrlCheckResponse response = savedLinkService.checkUrl(1L, "https://unknown.com");
+
+            assertThat(response.exists()).isFalse();
         }
     }
 


### PR DESCRIPTION
# 요약

FastAPI 분석 요청 전, 사용자가 입력한 URL이 이미 저장된 링크에 존재하는지 확인하는 API를 추가합니다.

- `GET /api/v1/saved-links/check?url={url}`
- `Analysis.original_url` 기준 exact match로 현재 멤버의 저장 링크 중복 여부 반환
- url 파라미터 누락 / 빈 문자열 시 400 처리

## 테스트

### 중복 URL 체크 테스트
<img width="1416" height="807" alt="image" src="https://github.com/user-attachments/assets/29bfb7e3-94a4-4fbc-9387-85931c63566b" />


# 연관 이슈 및 Close 할 이슈 작성

close #42

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?