### PR TITLE
[BUILD] 배포 자동화 세팅

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# GitHub
+.github/
+
+# Gradle
+.gradle/
+build/
+
+# IDE
+.idea/
+*.iml
+*.iws
+*.ipr
+out/
+
+# Logs
+*.log
+
+# Documentation
+HELP.md
+docs/
+
+# Environment
+.env
+.env.*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Windows
+gradlew.bat

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -56,12 +56,13 @@ jobs:
               "set -e",
               "cd ${{ vars.DEPLOY_DIR }}",
               "docker compose pull backend",
-              "docker compose up -d backend",
+              "docker compose up -d --wait --wait-timeout 120 backend",
               "docker image prune -f"
             ]' \
             --query "Command.CommandId" --output text)
           echo "CommandId=$cmd_id"
           # 완료까지 폴링 후 상태 검증
+          status=""
           for i in $(seq 1 30); do
             status=$(aws ssm get-command-invocation \
               --command-id "$cmd_id" \
@@ -78,3 +79,11 @@ jobs:
             esac
             sleep 10
           done
+          # 끝까지 Success가 아니면(시간 초과 등) 실패 처리
+          if [ "$status" != "Success" ]; then
+            echo "::error::Deploy did not reach Success within timeout (last status: $status)"
+            aws ssm get-command-invocation --command-id "$cmd_id" \
+              --instance-id "${{ secrets.APP_INSTANCE_ID }}" \
+              --query "StandardErrorContent" --output text || true
+            exit 1
+          fi

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,79 @@
+name: CD
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  id-token: write   # OIDC
+  contents: read
+
+jobs:
+  build-and-push:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.vars.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - id: vars
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ vars.IMAGE_NAME }}:latest
+            ${{ vars.IMAGE_NAME }}:${{ steps.vars.outputs.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Deploy via SSM SendCommand
+        run: |
+          cmd_id=$(aws ssm send-command \
+            --instance-ids "${{ secrets.APP_INSTANCE_ID }}" \
+            --document-name "AWS-RunShellScript" \
+            --comment "deploy devine-backend ${{ needs.build-and-push.outputs.sha }}" \
+            --parameters commands='[
+              "set -e",
+              "cd ${{ vars.DEPLOY_DIR }}",
+              "docker compose pull backend",
+              "docker compose up -d backend",
+              "docker image prune -f"
+            ]' \
+            --query "Command.CommandId" --output text)
+          echo "CommandId=$cmd_id"
+          # 완료까지 폴링 후 상태 검증
+          for i in $(seq 1 30); do
+            status=$(aws ssm get-command-invocation \
+              --command-id "$cmd_id" \
+              --instance-id "${{ secrets.APP_INSTANCE_ID }}" \
+              --query "Status" --output text 2>/dev/null || echo Pending)
+            echo "status=$status"
+            case "$status" in
+              Success) break ;;
+              Failed|Cancelled|TimedOut)
+                aws ssm get-command-invocation --command-id "$cmd_id" \
+                  --instance-id "${{ secrets.APP_INSTANCE_ID }}" \
+                  --query "StandardErrorContent" --output text
+                exit 1 ;;
+            esac
+            sleep 10
+          done

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -5,6 +5,7 @@ on:
     workflows: [CI]
     types: [completed]
     branches: [main]
+  workflow_dispatch:   # 수동 실행 (테스트/재배포/롤백)
 
 permissions:
   id-token: write   # OIDC
@@ -12,14 +13,14 @@ permissions:
 
 jobs:
   build-and-push:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.vars.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - id: vars
         run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev]
+  push:
+    branches: [dev, main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+      - run: chmod +x ./gradlew
+      - name: Run tests
+        run: ./gradlew test --no-daemon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /app
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
+
+COPY src src
+RUN ./gradlew bootJar -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /app
+COPY --chown=app:app --from=builder /app/build/libs/*.jar app.jar
+USER app
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,3 +1,15 @@
+server:
+  shutdown: graceful
+
+spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+  jpa:
+    properties:
+      hibernate:
+        show-sql: false
+    show-sql: false
+
 management:
   endpoint:
     health:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -12,3 +12,16 @@ spring:
       resourceserver:
         jwt:
           jwk-set-uri: http://localhost:9999/.well-known/jwks.json
+
+server:
+  port: 8080
+
+clerk:
+  issuer: https://test.clerk.local
+  secret-key: sk_test_dummy
+
+analysis-engine:
+  base-url: http://localhost:8000
+
+internal:
+  api-key: test-internal-api-key

--- a/src/test/java/com/linclean/domain/analysis/controller/VerdictStatisticsControllerTest.java
+++ b/src/test/java/com/linclean/domain/analysis/controller/VerdictStatisticsControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         value = AnalysisController.class,
         excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class, OAuth2ResourceServerAutoConfiguration.class}
 )
+@ActiveProfiles("test")
 class VerdictStatisticsControllerTest {
 
     @Autowired MockMvc mockMvc;

--- a/src/test/java/com/linclean/domain/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/com/linclean/domain/notice/controller/NoticeControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Instant;
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         value = NoticeController.class,
         excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class, OAuth2ResourceServerAutoConfiguration.class}
 )
+@ActiveProfiles("test")
 class NoticeControllerTest {
 
     @Autowired

--- a/src/test/java/com/linclean/domain/terms/controller/TermsControllerTest.java
+++ b/src/test/java/com/linclean/domain/terms/controller/TermsControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAut
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Instant;
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class, OAuth2ResourceServerAutoConfiguration.class}
 )
 @Import(TermsTypeSpringConverter.class)
+@ActiveProfiles("test")
 class TermsControllerTest {
 
     @Autowired MockMvc mockMvc;


### PR DESCRIPTION
# 요약

Docker 기반 배포 및 CI/CD 자동화 설정을 추가했습니다.

## Docker 배포 설정
- 멀티스테이지 빌드로 이미지 경량화 (JDK → JRE)
- 의존성 레이어 분리로 빌드 캐시 효율화
- non-root 유저 실행 및 `exec`를 통한 graceful shutdown 지원
- `.dockerignore`로 불필요한 파일 빌드 컨텍스트 제외
- prod 프로파일에 `server.shutdown: graceful` 및 SQL 로깅 비활성화 설정

## CI/CD GitHub Actions
- **CI.yml**: `PR→dev`, `push→dev/main` 에서 `./gradlew test` 실행. Testcontainers(postgres:17 + redis:7-alpine)가 러너 Docker로 자동 기동되어 별도 서비스 컨테이너 불필요.
- **CD.yml**: CI가 `main`에서 성공 완료되면 `workflow_run` 체이닝으로 트리거. 이미지 빌드·푸시(`latest` + git-sha) 후, GitHub OIDC로 AWS 역할 assume → SSM SendCommand로 App EC2에서 `docker compose pull/up backend` 실행.
- **CD 수동 실행(`workflow_dispatch`)** 추가: AWS 없이 빌드·푸시부터 단계별 테스트 및 재배포·롤백 가능. 두 이벤트(workflow_run/dispatch) 모두 지원하도록 `if` 가드·checkout `ref` 보정.

## 테스트 격리 수정 (.env 의존 제거)
- 테스트가 로컬 `.env`에 암묵적으로 의존해 CI(.env 없음)에서 실패하던 문제 수정.
- `application-test.yml`에 `server.port`·`clerk`·`analysis-engine`·`internal` 값을 추가해 test 프로파일이 자급자족하도록 변경.
- `@WebMvcTest` 컨트롤러 테스트 3종에 `@ActiveProfiles("test")` 추가 (dev 프로파일로 로드되어 `${API_PORT}` 미해소되던 문제 해결).
- 운영(prod)은 영향 없음 — `application.yml` 원본 placeholder는 그대로라 배포 `.env`에서 실제 값 주입.

> 참고: CI는 머지 즉시 동작합니다. CD의 deploy 잡은 AWS 인프라(OIDC 역할·EC2·SSM)와 GitHub Secrets/Variables가 준비돼야 그린이 됩니다.

# 연관 이슈 및 Close 할 이슈 작성

close #40

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?