### PR TITLE
[FEATURE] 페이지 불가용(PAGE_UNAVAILABLE) 처리 추가

### DIFF
--- a/src/main/java/com/linclean/domain/analysis/dto/response/AnalysisResponse.java
+++ b/src/main/java/com/linclean/domain/analysis/dto/response/AnalysisResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.linclean.domain.analysis.entity.Analysis;
 import com.linclean.domain.analysis.entity.AnalysisReason;
 import com.linclean.domain.analysis.entity.AnalysisStatus;
+import com.linclean.domain.analysis.entity.Stages;
 import com.linclean.domain.analysis.entity.Verdict;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -34,22 +35,32 @@ public class AnalysisResponse {
     private final Integer errorStage;
     private final String errorMessage;
 
+    private final String contentAnalysisError;
+
     public static AnalysisResponse forQueued(UUID analysisId) {
         return new AnalysisResponse(
                 analysisId, AnalysisStatus.QUEUED,
                 null, null, null, null, null, null, null, null,
-                null, null, null
+                null, null, null,
+                null
         );
     }
 
     public static AnalysisResponse forSucceeded(Analysis analysis, List<AnalysisReason> reasons) {
+        String contentAnalysisError = null;
+        Stages stages = analysis.getStages();
+        if (stages != null && stages.getContentAnalysis() != null
+                && !stages.getContentAnalysis().isFetched()) {
+            contentAnalysisError = stages.getContentAnalysis().getReason();
+        }
         return new AnalysisResponse(
                 analysis.getAnalysisId(), AnalysisStatus.SUCCEEDED,
                 analysis.getOriginalUrl(), analysis.getFinalUrl(),
                 analysis.getVerdict(), analysis.getScore(), analysis.getSummary(),
                 reasons.stream().map(ReasonDto::from).toList(),
                 analysis.getAnalyzedAt(), analysis.getElapsedMs(),
-                null, null, null
+                null, null, null,
+                contentAnalysisError
         );
     }
 
@@ -57,7 +68,8 @@ public class AnalysisResponse {
         return new AnalysisResponse(
                 analysis.getAnalysisId(), AnalysisStatus.FAILED,
                 analysis.getOriginalUrl(), null, null, null, null, null, null, null,
-                analysis.getErrorCode(), analysis.getErrorStage(), analysis.getErrorMessage()
+                analysis.getErrorCode(), analysis.getErrorStage(), analysis.getErrorMessage(),
+                null
         );
     }
 

--- a/src/main/java/com/linclean/domain/analysis/entity/Stages.java
+++ b/src/main/java/com/linclean/domain/analysis/entity/Stages.java
@@ -79,5 +79,8 @@ public class Stages {
         private boolean hasPasswordField;
         private String aiVerdict;
         private String aiReason;
+        private Integer statusCode;
+        private String error;
+        private String reason;
     }
 }


### PR DESCRIPTION
# 요약

URL 검사 콜백 흐름에서 FastAPI가 전달하는 `stages.content_analysis`의 `statusCode`, `error`, `reason` 필드를 Spring이 역직렬화하지 못하던 문제를 수정하고, 페이지 불가용 사유를 클라이언트 응답에 노출합니다.

- `ContentAnalysisStage`에 `statusCode`, `error`, `reason` 필드 추가
- `AnalysisResponse`에 `contentAnalysisError` 필드 추가 — `fetched=false`일 때만 JSON에 노출 (`@JsonInclude(NON_NULL)`)
- 기존 정상 fetch 케이스의 응답 구조는 변경 없음

# 연관 이슈 및 Close 할 이슈 작성

close #46

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?