### PR TITLE
[CHORE] 서버 로그 JSON 파일 기록 및 조회 및 디스코드 알림 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     // Swagger (SpringDoc OpenAPI)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
+    // Logging (JSON 파일 로그)
+    implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/linclean/global/log/DiscordWebhookAppender.java
+++ b/src/main/java/com/linclean/global/log/DiscordWebhookAppender.java
@@ -1,0 +1,123 @@
+package com.linclean.global.log;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
+import ch.qos.logback.core.AppenderBase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * ERROR 로그를 디스코드 웹훅으로 실시간 전송하는 logback appender.
+ *
+ * <p>logback-spring.xml 에서 {@code <webhookUrl>${DISCORD_WEBHOOK_URL:-}</webhookUrl>} 로 주입한다.
+ * URL이 비어 있으면 아무 동작도 하지 않으므로(로컬/미설정 환경) 안전하다.
+ * Spring 컨텍스트보다 먼저 동작하므로 빈 주입 대신 표준 {@link HttpClient}를 사용한다.
+ *
+ * <p>전송은 {@link HttpClient#sendAsync} 로 비동기 처리하며, 디스코드 분당 30회 한도를
+ * 넘기지 않도록 분당 {@code maxPerMinute}건으로 제한(초과분은 드롭)한다.
+ */
+public class DiscordWebhookAppender extends AppenderBase<ILoggingEvent> {
+
+    /** 디스코드 content 최대 길이 2000자. 코드블록/여유분 고려해 보수적으로 자른다. */
+    private static final int MAX_CONTENT = 1900;
+    private static final DateTimeFormatter TS_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private String webhookUrl;
+    private int maxPerMinute = 20;
+
+    private HttpClient httpClient;
+
+    // 분당 호출 제한 상태
+    private long windowStartMs = 0;
+    private int sentInWindow = 0;
+
+    public void setWebhookUrl(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+
+    public void setMaxPerMinute(int maxPerMinute) {
+        this.maxPerMinute = maxPerMinute;
+    }
+
+    @Override
+    public void start() {
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(3))
+                .build();
+        super.start();
+    }
+
+    @Override
+    protected void append(ILoggingEvent event) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            return; // 미설정 환경에서는 no-op
+        }
+        if (!allow()) {
+            return; // 분당 제한 초과 → 드롭
+        }
+        try {
+            String payload = buildPayload(event);
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(webhookUrl))
+                    .timeout(Duration.ofSeconds(5))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(payload))
+                    .build();
+            // 비동기 전송 - 실패해도 애플리케이션 로깅 흐름에 영향 주지 않음
+            httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding())
+                    .exceptionally(ex -> null);
+        } catch (Exception e) {
+            // appender 는 절대 예외를 던지지 않는다
+            addError("디스코드 웹훅 전송 실패", e);
+        }
+    }
+
+    private synchronized boolean allow() {
+        long now = System.currentTimeMillis();
+        if (now - windowStartMs >= 60_000) {
+            windowStartMs = now;
+            sentInWindow = 0;
+        }
+        if (sentInWindow < maxPerMinute) {
+            sentInWindow++;
+            return true;
+        }
+        return false;
+    }
+
+    private String buildPayload(ILoggingEvent event) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("🚨 **[ERROR]** ").append(TS_FORMAT.format(Instant.ofEpochMilli(event.getTimeStamp())))
+                .append('\n')
+                .append("**logger**: ").append(event.getLoggerName()).append('\n')
+                .append("**message**: ").append(event.getFormattedMessage());
+
+        IThrowableProxy throwableProxy = event.getThrowableProxy();
+        if (throwableProxy != null) {
+            sb.append("\n```\n")
+                    .append(ThrowableProxyUtil.asString(throwableProxy))
+                    .append("\n```");
+        }
+
+        String content = sb.toString();
+        if (content.length() > MAX_CONTENT) {
+            content = content.substring(0, MAX_CONTENT) + "\n...(생략)";
+        }
+
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
+        node.put("content", content);
+        return node.toString();
+    }
+}

--- a/src/main/java/com/linclean/global/log/LogViewController.java
+++ b/src/main/java/com/linclean/global/log/LogViewController.java
@@ -1,0 +1,118 @@
+package com.linclean.global.log;
+
+import com.linclean.global.web.ApiResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * 서버 로그 파일 조회용 내부 엔드포인트.
+ *
+ * <p>{@code /internal/**} 경로이므로 {@code InternalApiKeyFilter}가 자동 적용된다.
+ * 호출 시 {@code X-Internal-Api-Key} 헤더에 {@code internal.api-key} 값이 필요하다.
+ * SSH 없이 IntelliJ HTTP Client / 브라우저에서 로그를 확인하기 위한 용도.
+ */
+@RestController
+@RequestMapping("/internal/logs")
+public class LogViewController {
+
+    private static final Pattern DATE_PATTERN = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+    private static final String ACTIVE_FILE = "app.json";
+
+    @Value("${LOG_DIR:logs}")
+    private String logDir;
+
+    /** 사용 가능한 로그 파일 목록(파일명/크기). */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<LogFileInfo>>> listLogFiles() throws IOException {
+        Path dir = Paths.get(logDir);
+        if (!Files.isDirectory(dir)) {
+            return ResponseEntity.ok(ApiResponse.of(List.of()));
+        }
+        try (Stream<Path> files = Files.list(dir)) {
+            List<LogFileInfo> result = files
+                    .filter(LogViewController::isLogFile)
+                    .sorted(Comparator.comparing((Path p) -> p.getFileName().toString()).reversed())
+                    .map(LogViewController::toInfo)
+                    .toList();
+            return ResponseEntity.ok(ApiResponse.of(result));
+        }
+    }
+
+    /**
+     * 특정 날짜의 로그 조회. 오늘 날짜는 롤링 전이므로 활성 파일(app.json)을 가리킨다.
+     *
+     * @param date  yyyy-MM-dd
+     * @param level (선택) 해당 레벨 라인만 필터 (예: ERROR)
+     * @param lines (선택) 마지막 N줄만 반환
+     */
+    @GetMapping("/{date}")
+    public ResponseEntity<String> getLogByDate(
+            @PathVariable String date,
+            @RequestParam(required = false) String level,
+            @RequestParam(required = false) Integer lines
+    ) throws IOException {
+        if (!DATE_PATTERN.matcher(date).matches()) {
+            return ResponseEntity.badRequest().body("date 형식은 yyyy-MM-dd 여야 합니다.");
+        }
+
+        String fileName = date.equals(LocalDate.now().toString())
+                ? ACTIVE_FILE
+                : "app." + date + ".json";
+
+        Path dir = Paths.get(logDir).toAbsolutePath().normalize();
+        Path file = dir.resolve(fileName).normalize();
+        if (!file.startsWith(dir) || !Files.isRegularFile(file)) {
+            return ResponseEntity.notFound().build();
+        }
+
+        List<String> all = Files.readAllLines(file, StandardCharsets.UTF_8);
+        Stream<String> stream = all.stream();
+        if (level != null && !level.isBlank()) {
+            String needle = "\"level\":\"" + level.toUpperCase() + "\"";
+            stream = stream.filter(line -> line.contains(needle));
+        }
+        List<String> filtered = stream.toList();
+        if (lines != null && lines > 0 && filtered.size() > lines) {
+            filtered = filtered.subList(filtered.size() - lines, filtered.size());
+        }
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("application/x-ndjson; charset=UTF-8"))
+                .body(String.join("\n", filtered));
+    }
+
+    private static boolean isLogFile(Path p) {
+        String name = p.getFileName().toString();
+        return name.startsWith("app") && name.endsWith(".json");
+    }
+
+    private static LogFileInfo toInfo(Path p) {
+        long size;
+        try {
+            size = Files.size(p);
+        } catch (IOException e) {
+            size = -1;
+        }
+        return new LogFileInfo(p.getFileName().toString(), size);
+    }
+
+    public record LogFileInfo(String fileName, long sizeBytes) {
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Spring Boot 기본 패턴/규칙 및 콘솔 appender 재사용 (docker logs 용) -->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <!-- 로그 저장 디렉터리 (미설정 시 작업 디렉터리 기준 logs/) -->
+    <property name="LOG_DIR" value="${LOG_DIR:-logs}"/>
+
+    <!-- 일 단위 JSON 롤링 파일: 한 줄 = 로그 1건 -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/app.json</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/app.%d{yyyy-MM-dd}.json</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <!-- ERROR 발생 시 디스코드 웹훅 알림 (URL 미설정 시 no-op) -->
+    <appender name="DISCORD" class="com.linclean.global.log.DiscordWebhookAppender">
+        <webhookUrl>${DISCORD_WEBHOOK_URL:-}</webhookUrl>
+    </appender>
+    <!-- 요청 스레드를 막지 않도록 비동기로 감싸고, ERROR 만 큐에 넣음 -->
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <appender-ref ref="DISCORD"/>
+        <discardingThreshold>0</discardingThreshold>
+        <queueSize>512</queueSize>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="ASYNC_DISCORD"/>
+    </root>
+</configuration>


### PR DESCRIPTION
# 요약

데모 행사 중 발생하는 오류를 SSH 접속 없이 기록·확인하기 위한 로깅 기능을 추가했습니다.

- **JSON 파일 로깅**: `logback-spring.xml`로 일 단위 롤링 JSON 로그 저장 (`logs/app.json` → `app.YYYY-MM-DD.json`, 7일 보관, `logstash-logback-encoder`)
- **디스코드 에러 알림**: 모든 `ERROR` 로그를 디스코드 웹훅으로 실시간 전송. URL 미설정 시 no-op, 분당 호출 제한, 비동기 처리로 요청 스레드 비차단
- **로그 조회 엔드포인트**: `GET /internal/logs`(목록), `GET /internal/logs/{date}?level=ERROR&lines=N`(조회). 기존 `InternalApiKeyFilter`로 자동 보호되어 `X-Internal-Api-Key` 헤더로 IntelliJ HTTP Client/브라우저에서 조회 가능

### 배포 전 필요한 env
- `DISCORD_WEBHOOK_URL`: 디스코드 채널 웹훅 URL (compose backend env에 주입)
- `LOG_DIR`: 선택, 기본 `logs`
- `INTERNAL_API_KEY`: 기존 값 재사용

> 로그는 컨테이너 내부 `/app/logs`에 쌓여 재배포 시 이전 파일은 사라지지만, 디스코드 알림은 실시간이라 에러는 놓치지 않습니다. 영구 보관이 필요하면 추후 compose 볼륨 마운트(`./logs:/app/logs`)로 확장 가능합니다.

# 연관 이슈 및 Close 할 이슈 작성

close #53

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?