### PR TITLE
[FIX] 로그 디렉터리 권한 문제 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
 COPY --chown=app:app --from=builder /app/build/libs/*.jar app.jar
+# 로그 디렉터리를 app 소유로 생성 (named volume 초기화 시 권한 상속)
+RUN mkdir -p /app/logs && chown app:app /app/logs
 USER app
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]


### PR DESCRIPTION
# 요약

새 로깅 기능(#53) 배포 후 CD가 실패했습니다. 원인은 non-root(`app`) 컨테이너가 마운트된 로그 디렉터리(root 소유)에 `/app/logs/app.json`을 쓰지 못해 기동에 실패한 것입니다. (응급으로 호스트 폴더 `chmod 777`하여 정상화)

근본 수정으로 Dockerfile에서 `/app/logs`를 `app` 유저 소유로 생성합니다.

```dockerfile
RUN mkdir -p /app/logs && chown app:app /app/logs
```

> ⚠️ **EC2 docker-compose 변경 필요(레포 밖):** 현재 로그 폴더가 **바인드 마운트**라 이미지의 `chown`이 마운트에 가려집니다. 아래처럼 **named volume**으로 바꿔야 이 수정이 완전히 적용됩니다(Docker가 이미지 소유권으로 볼륨을 초기화 → chmod 불필요, 재배포 안전).
>
> ```yaml
> services:
>   backend:
>     volumes:
>       - linclean-logs:/app/logs
> volumes:
>   linclean-logs:
> ```

# 연관 이슈 및 Close 할 이슈 작성

close #56

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?